### PR TITLE
Fixing corpus loading in LocalTestSpout and nohup.out

### DIFF
--- a/bin/start-web-compute.sh
+++ b/bin/start-web-compute.sh
@@ -4,7 +4,7 @@ set -e
 
 echo Starting web server...
 
-nohup java -cp chatalytics-web-0.3-with-dependencies.jar:config -Dlogback.configurationFile=config/web/logback.xml com.chatalytics.web.ServerMain &> /dev/null
+nohup java -cp chatalytics-web-0.3-with-dependencies.jar:config -Dlogback.configurationFile=config/web/logback.xml com.chatalytics.web.ServerMain > /dev/null 2>&1 &
 
 echo Starting compute server...
 

--- a/compute/src/main/java/com/chatalytics/compute/storm/spout/LocalTestSpout.java
+++ b/compute/src/main/java/com/chatalytics/compute/storm/spout/LocalTestSpout.java
@@ -10,7 +10,6 @@ import com.chatalytics.core.model.Message;
 import com.chatalytics.core.model.Room;
 import com.chatalytics.core.model.User;
 import com.google.common.collect.Lists;
-import com.google.common.io.Resources;
 
 import org.apache.storm.shade.com.google.common.collect.Maps;
 import org.joda.time.DateTime;
@@ -26,8 +25,8 @@ import backtype.storm.tuple.Fields;
 import backtype.storm.tuple.Values;
 
 import java.io.IOException;
-import java.net.URI;
 import java.net.URISyntaxException;
+import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.List;
@@ -94,10 +93,13 @@ public class LocalTestSpout extends BaseRichSpout {
 
         String filename = localConfig.messageCorpusFile;
         try {
-            URI uri = Resources.getResource(localConfig.messageCorpusFile).toURI();
-            this.sentences = Files.readAllLines(Paths.get(uri));
+            URL corpusURL = ClassLoader.getSystemResource(filename);
+            if (corpusURL == null) {
+                throw new IllegalArgumentException("Can't find corpus. Specified: " + filename);
+            }
+            this.sentences = Files.readAllLines(Paths.get(corpusURL.toURI()));
         } catch (IOException | URISyntaxException e) {
-            throw new RuntimeException("Can't read file from config. Specified: " + filename, e);
+            throw new IllegalArgumentException("Can't read corpus. Specified: " + filename, e);
         }
 
         // create the number generator

--- a/config/chatalytics.yaml
+++ b/config/chatalytics.yaml
@@ -15,4 +15,4 @@ backfillerConfig:
     startDate: '2016-03-30T00:00:00Z'
 localTestConfig:
     randomSeed: 0
-    messageCorpusFile: corpus/test_corpus.txt
+    messageCorpusFile: compute/corpus/test_corpus.txt


### PR DESCRIPTION
- The local test spout was looking in resources to load the corpus but it should instead look in the classpath
- Change the exceptions to IllegalArgumentExceptions
- The webserver was creating a nohup.out file when starting in docker. Stop doing that.
