### PR TITLE
Don't close all the sessions in server sockets

### DIFF
--- a/compute/src/main/java/com/chatalytics/compute/realtime/RealtimeResource.java
+++ b/compute/src/main/java/com/chatalytics/compute/realtime/RealtimeResource.java
@@ -90,20 +90,21 @@ public class RealtimeResource {
     }
 
     /**
-     * Tries to close the session
+     * Closes a session
      *
+     * @param session
+     *            The session to close
      * @param reason
-     *            Reason for closing
+     *            The reason for closing
      */
     @OnClose
-    public void close(CloseReason reason) {
-        LOG.info("Closing {} sessions", sessions.size());
-        for (Session session : sessions) {
-            try {
-                session.close();
-            } catch (IOException e) {
-                LOG.warn("Couldn't close {}", session.getId());
-            }
+    public void close(Session session, CloseReason reason) {
+        LOG.info("Closing session {}. Reason {}", session.getId(), reason);
+        try {
+            session.close();
+            sessions.remove(session);
+        } catch (IOException e) {
+            LOG.warn("Couldn't close {}", session.getId());
         }
     }
 

--- a/web/src/main/java/com/chatalytics/web/resources/EventsResource.java
+++ b/web/src/main/java/com/chatalytics/web/resources/EventsResource.java
@@ -64,15 +64,22 @@ public class EventsResource {
         }
     }
 
+    /**
+     * Closes a session
+     *
+     * @param session
+     *            The session to close
+     * @param reason
+     *            The reason for closing
+     */
     @OnClose
-    public void close(CloseReason reason) {
-        LOG.info("Closing {} sessions", sessions.size());
-        for (Session session : sessions) {
-            try {
-                session.close();
-            } catch (IOException e) {
-                LOG.warn("Couldn't close {}", session.getId());
-            }
+    public void close(Session session, CloseReason reason) {
+        LOG.info("Closing session {}. Reason {}", session.getId(), reason);
+        try {
+            session.close();
+            sessions.remove(session);
+        } catch (IOException e) {
+            LOG.warn("Couldn't close {}", session.getId());
         }
     }
 


### PR DESCRIPTION
The realtime compute and web resources were closing all sessions instead of the one that was initiating a close session. Fix that
