### PR TITLE
Adding a message summary bolt, changing to query params

### DIFF
--- a/compute/src/main/java/com/chatalytics/compute/storm/ChatAlyticsStormTopology.java
+++ b/compute/src/main/java/com/chatalytics/compute/storm/ChatAlyticsStormTopology.java
@@ -2,6 +2,7 @@ package com.chatalytics.compute.storm;
 
 import com.chatalytics.compute.storm.bolt.EmojiCounterBolt;
 import com.chatalytics.compute.storm.bolt.EntityExtractionBolt;
+import com.chatalytics.compute.storm.bolt.MessageSummaryBolt;
 import com.chatalytics.compute.storm.bolt.RealtimeBolt;
 import com.chatalytics.compute.storm.spout.HipChatMessageSpout;
 import com.chatalytics.compute.storm.spout.LocalTestSpout;
@@ -52,10 +53,15 @@ public class ChatAlyticsStormTopology {
         topologyBuilder.setBolt(EmojiCounterBolt.BOLT_ID, new EmojiCounterBolt())
                        .shuffleGrouping(inputSpoutId);
 
+        // message summary bolt
+        topologyBuilder.setBolt(MessageSummaryBolt.BOLT_ID, new MessageSummaryBolt())
+                       .shuffleGrouping(inputSpoutId);
+
         // realtime bolt
         topologyBuilder.setBolt(RealtimeBolt.BOLT_ID, new RealtimeBolt())
                        .shuffleGrouping(EmojiCounterBolt.BOLT_ID)
-                       .shuffleGrouping(EntityExtractionBolt.BOLT_ID);
+                       .shuffleGrouping(EntityExtractionBolt.BOLT_ID)
+                       .shuffleGrouping(MessageSummaryBolt.BOLT_ID);
 
         return topologyBuilder.createTopology();
     }

--- a/compute/src/main/java/com/chatalytics/compute/storm/bolt/ChatAlyticsBaseBolt.java
+++ b/compute/src/main/java/com/chatalytics/compute/storm/bolt/ChatAlyticsBaseBolt.java
@@ -1,0 +1,43 @@
+package com.chatalytics.compute.storm.bolt;
+
+import com.chatalytics.compute.config.ConfigurationConstants;
+import com.chatalytics.compute.util.YamlUtils;
+import com.chatalytics.core.config.ChatAlyticsConfig;
+
+import backtype.storm.task.OutputCollector;
+import backtype.storm.task.TopologyContext;
+import backtype.storm.topology.base.BaseRichBolt;
+
+import java.util.Map;
+
+/**
+ * Inherit from this bolt if you want your prepare method to be called with a
+ * {@link ChatAlyticsConfig}
+ *
+ * @author giannis
+ */
+public abstract class ChatAlyticsBaseBolt extends BaseRichBolt {
+
+    private static final long serialVersionUID = -7961960405946887688L;
+
+    @Override
+    public void prepare(@SuppressWarnings("rawtypes") Map stormConf, TopologyContext context,
+            OutputCollector collector) {
+        String configStr = (String) stormConf.get(ConfigurationConstants.CHATALYTICS_CONFIG.txt);
+        ChatAlyticsConfig config = YamlUtils.readYamlFromString(configStr, ChatAlyticsConfig.class);
+        prepare(config, stormConf, context, collector);
+    }
+
+    /**
+     * Prepare method to implement that also passes a {@link ChatAlyticsConfig}
+     *
+     * @param config The {@link ChatAlyticsConfig}
+     * @param stormConf The storm config
+     * @param context Topology context
+     * @param collector The storm collector
+     */
+    public abstract void prepare(ChatAlyticsConfig config,
+            @SuppressWarnings("rawtypes") Map stormConf, TopologyContext context,
+            OutputCollector collector);
+
+}

--- a/compute/src/main/java/com/chatalytics/compute/storm/bolt/EmojiCounterBolt.java
+++ b/compute/src/main/java/com/chatalytics/compute/storm/bolt/EmojiCounterBolt.java
@@ -28,7 +28,7 @@ public class EmojiCounterBolt extends ChatAlyticsBaseBolt {
 
     private static final long serialVersionUID = -3543087188985057557L;
     public static final String BOLT_ID = "EMOJI_COUNTER_BOLT_ID";
-    public static final String EMOJI_ENTITY_FIELD_STR = "emoji-entity";
+    private static final String EMOJI_ENTITY_FIELD_STR = "emoji-entity";
     private static final Logger LOG = LoggerFactory.getLogger(EmojiCounterBolt.class);
 
     private IEmojiDAO emojiDao;
@@ -45,10 +45,6 @@ public class EmojiCounterBolt extends ChatAlyticsBaseBolt {
     public void execute(Tuple input) {
         LOG.info("Got tuple: {}", input);
         FatMessage fatMessage = (FatMessage) input.getValue(0);
-        if (fatMessage == null) {
-            LOG.warn("Got a null tuple");
-            return;
-        }
 
         List<EmojiEntity> emojis = getEmojisFromMessage(fatMessage);
 

--- a/compute/src/main/java/com/chatalytics/compute/storm/bolt/EmojiCounterBolt.java
+++ b/compute/src/main/java/com/chatalytics/compute/storm/bolt/EmojiCounterBolt.java
@@ -1,9 +1,7 @@
 package com.chatalytics.compute.storm.bolt;
 
-import com.chatalytics.compute.config.ConfigurationConstants;
 import com.chatalytics.compute.db.dao.ChatAlyticsDAOFactory;
 import com.chatalytics.compute.db.dao.IEmojiDAO;
-import com.chatalytics.compute.util.YamlUtils;
 import com.chatalytics.core.config.ChatAlyticsConfig;
 import com.chatalytics.core.model.EmojiEntity;
 import com.chatalytics.core.model.FatMessage;
@@ -18,7 +16,6 @@ import org.slf4j.LoggerFactory;
 import backtype.storm.task.OutputCollector;
 import backtype.storm.task.TopologyContext;
 import backtype.storm.topology.OutputFieldsDeclarer;
-import backtype.storm.topology.base.BaseRichBolt;
 import backtype.storm.tuple.Fields;
 import backtype.storm.tuple.Tuple;
 import backtype.storm.tuple.Values;
@@ -27,7 +24,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.PrimitiveIterator.OfInt;
 
-public class EmojiCounterBolt extends BaseRichBolt {
+public class EmojiCounterBolt extends ChatAlyticsBaseBolt {
 
     private static final long serialVersionUID = -3543087188985057557L;
     public static final String BOLT_ID = "EMOJI_COUNTER_BOLT_ID";
@@ -38,10 +35,8 @@ public class EmojiCounterBolt extends BaseRichBolt {
     private OutputCollector collector;
 
     @Override
-    public void prepare(@SuppressWarnings("rawtypes") Map conf, TopologyContext context,
-                        OutputCollector collector) {
-        String configStr = (String) conf.get(ConfigurationConstants.CHATALYTICS_CONFIG.txt);
-        ChatAlyticsConfig config = YamlUtils.readYamlFromString(configStr, ChatAlyticsConfig.class);
+    public void prepare(ChatAlyticsConfig config, @SuppressWarnings("rawtypes") Map conf,
+                        TopologyContext context, OutputCollector collector) {
         emojiDao = ChatAlyticsDAOFactory.getEmojiDAO(config);
         this.collector = collector;
     }

--- a/compute/src/main/java/com/chatalytics/compute/storm/bolt/EntityExtractionBolt.java
+++ b/compute/src/main/java/com/chatalytics/compute/storm/bolt/EntityExtractionBolt.java
@@ -1,9 +1,7 @@
 package com.chatalytics.compute.storm.bolt;
 
-import com.chatalytics.compute.config.ConfigurationConstants;
 import com.chatalytics.compute.db.dao.ChatAlyticsDAOFactory;
 import com.chatalytics.compute.db.dao.IEntityDAO;
-import com.chatalytics.compute.util.YamlUtils;
 import com.chatalytics.core.config.ChatAlyticsConfig;
 import com.chatalytics.core.model.ChatEntity;
 import com.chatalytics.core.model.FatMessage;
@@ -20,7 +18,6 @@ import org.slf4j.LoggerFactory;
 import backtype.storm.task.OutputCollector;
 import backtype.storm.task.TopologyContext;
 import backtype.storm.topology.OutputFieldsDeclarer;
-import backtype.storm.topology.base.BaseRichBolt;
 import backtype.storm.tuple.Fields;
 import backtype.storm.tuple.Tuple;
 import backtype.storm.tuple.Values;
@@ -44,7 +41,7 @@ import java.util.Map;
  * @author giannis
  *
  */
-public class EntityExtractionBolt extends BaseRichBolt {
+public class EntityExtractionBolt extends ChatAlyticsBaseBolt {
 
     private static final long serialVersionUID = -1586393277809132608L;
     private static final Logger LOG = LoggerFactory.getLogger(EntityExtractionBolt.class);
@@ -58,10 +55,8 @@ public class EntityExtractionBolt extends BaseRichBolt {
     private OutputCollector collector;
 
     @Override
-    public void prepare(@SuppressWarnings("rawtypes") Map conf, TopologyContext context,
-                        OutputCollector collector) {
-        String configStr = (String) conf.get(ConfigurationConstants.CHATALYTICS_CONFIG.txt);
-        ChatAlyticsConfig config = YamlUtils.readYamlFromString(configStr, ChatAlyticsConfig.class);
+    public void prepare(ChatAlyticsConfig config, @SuppressWarnings("rawtypes") Map conf,
+                        TopologyContext context, OutputCollector collector) {
         classifier = getClassifier(config);
         entityDao = ChatAlyticsDAOFactory.getEntityDAO(config);
         if (!entityDao.isRunning()) {

--- a/compute/src/main/java/com/chatalytics/compute/storm/bolt/EntityExtractionBolt.java
+++ b/compute/src/main/java/com/chatalytics/compute/storm/bolt/EntityExtractionBolt.java
@@ -83,10 +83,6 @@ public class EntityExtractionBolt extends ChatAlyticsBaseBolt {
     public void execute(Tuple input) {
         LOG.info("Got tuple: {}", input);
         FatMessage fatMessage = (FatMessage) input.getValue(0);
-        if (fatMessage == null) {
-            LOG.warn("Got a null tuple");
-            return;
-        }
 
         List<ChatEntity> entities = extractEntities(fatMessage);
         for (ChatEntity entity : entities) {

--- a/compute/src/main/java/com/chatalytics/compute/storm/bolt/MessageSummaryBolt.java
+++ b/compute/src/main/java/com/chatalytics/compute/storm/bolt/MessageSummaryBolt.java
@@ -1,0 +1,59 @@
+package com.chatalytics.compute.storm.bolt;
+
+import com.chatalytics.core.config.ChatAlyticsConfig;
+import com.chatalytics.core.model.FatMessage;
+import com.chatalytics.core.model.MessageSummary;
+
+import org.joda.time.DateTime;
+
+import backtype.storm.task.OutputCollector;
+import backtype.storm.task.TopologyContext;
+import backtype.storm.topology.OutputFieldsDeclarer;
+import backtype.storm.tuple.Fields;
+import backtype.storm.tuple.Tuple;
+import backtype.storm.tuple.Values;
+
+import java.util.Map;
+
+/**
+ * Bolt that simply emits a summarized event for every chat message
+ *
+ * @author giannis
+ */
+public class MessageSummaryBolt extends ChatAlyticsBaseBolt {
+
+    private static final long serialVersionUID = 2580435620776513082L;
+
+    public static final String BOLT_ID = "MESSAGE_COUNTER_BOLT_ID";
+    private static final String MESSAGE_SUMMARY_FIELD_STR = "message-summary";
+
+    private OutputCollector collector;
+
+    @Override
+    public void prepare(ChatAlyticsConfig config, @SuppressWarnings("rawtypes") Map stormConf,
+                        TopologyContext context, OutputCollector collector) {
+        this.collector = collector;
+    }
+
+    @Override
+    public void execute(Tuple input) {
+        FatMessage fatMessage = (FatMessage) input.getValue(0);
+        String username = null;
+        String roomName = null;
+        if (fatMessage.getUser() != null) {
+            username = fatMessage.getUser().getMentionName();
+        }
+        if (fatMessage.getRoom() != null) {
+            roomName = fatMessage.getRoom().getName();
+        }
+        DateTime messageDate = fatMessage.getMessage().getDate();
+        MessageSummary chatSummary = new MessageSummary(username, roomName, messageDate);
+        collector.emit(new Values(chatSummary));
+    }
+
+    @Override
+    public void declareOutputFields(OutputFieldsDeclarer fields) {
+        fields.declare(new Fields(MESSAGE_SUMMARY_FIELD_STR));
+    }
+
+}

--- a/compute/src/main/java/com/chatalytics/compute/storm/bolt/RealtimeBolt.java
+++ b/compute/src/main/java/com/chatalytics/compute/storm/bolt/RealtimeBolt.java
@@ -1,7 +1,5 @@
 package com.chatalytics.compute.storm.bolt;
 
-import com.chatalytics.compute.config.ConfigurationConstants;
-import com.chatalytics.compute.util.YamlUtils;
 import com.chatalytics.core.config.ChatAlyticsConfig;
 import com.chatalytics.core.model.ChatAlyticsEvent;
 import com.chatalytics.core.realtime.ChatAlyticsEventEncoder;
@@ -16,7 +14,6 @@ import org.slf4j.LoggerFactory;
 import backtype.storm.task.OutputCollector;
 import backtype.storm.task.TopologyContext;
 import backtype.storm.topology.OutputFieldsDeclarer;
-import backtype.storm.topology.base.BaseRichBolt;
 import backtype.storm.tuple.Tuple;
 
 import java.io.IOException;
@@ -42,7 +39,7 @@ import static com.google.common.base.CaseFormat.UPPER_CAMEL;
  * @author giannis
  */
 @ClientEndpoint(encoders = { ChatAlyticsEventEncoder.class, ConnectionTypeEncoderDecoder.class })
-public class RealtimeBolt extends BaseRichBolt {
+public class RealtimeBolt extends ChatAlyticsBaseBolt {
 
     private static final long serialVersionUID = -214311696491358951L;
     private static final Logger LOG = LoggerFactory.getLogger(RealtimeBolt.class);
@@ -50,11 +47,8 @@ public class RealtimeBolt extends BaseRichBolt {
     private Session session;
 
     @Override
-    public void prepare(@SuppressWarnings("rawtypes") Map conf, TopologyContext context,
-                        OutputCollector collector) {
-        String configStr = (String) conf.get(ConfigurationConstants.CHATALYTICS_CONFIG.txt);
-        ChatAlyticsConfig config = YamlUtils.readYamlFromString(configStr, ChatAlyticsConfig.class);
-
+    public void prepare(ChatAlyticsConfig config, @SuppressWarnings("rawtypes") Map conf,
+                        TopologyContext context, OutputCollector collector) {
         WebSocketContainer webSocketContainer = getWebSocketContainer();
         this.session = openRealtimeConnection(webSocketContainer, config);
     }

--- a/core/src/main/java/com/chatalytics/core/model/MessageSummary.java
+++ b/core/src/main/java/com/chatalytics/core/model/MessageSummary.java
@@ -1,0 +1,29 @@
+package com.chatalytics.core.model;
+
+import org.joda.time.DateTime;
+
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+
+/**
+ * Summary event for a chat message. This object does not include the actual message and can be
+ * safely exposed through the ChatAlytics API.
+ *
+ * @author giannis
+ */
+@Getter
+@EqualsAndHashCode
+@AllArgsConstructor
+public class MessageSummary implements IMentionable {
+
+    private static final long serialVersionUID = 4610523559744723974L;
+
+    private final String username;
+    private final String roomName;
+    private final DateTime mentionTime;
+    /**
+     * Occurrences will always be 1. This field is here to make JSON serialization easier
+     */
+    private final int occurrences = 1;
+}

--- a/web/src/main/java/com/chatalytics/web/constant/WebConstants.java
+++ b/web/src/main/java/com/chatalytics/web/constant/WebConstants.java
@@ -1,0 +1,6 @@
+package com.chatalytics.web.constant;
+
+public class WebConstants {
+
+    public static final String API_PATH = "/api/v0/";
+}

--- a/web/src/main/java/com/chatalytics/web/resources/TopEmojisResource.java
+++ b/web/src/main/java/com/chatalytics/web/resources/TopEmojisResource.java
@@ -4,6 +4,7 @@ import com.chatalytics.compute.db.dao.ChatAlyticsDAOFactory;
 import com.chatalytics.compute.db.dao.IEmojiDAO;
 import com.chatalytics.core.config.ChatAlyticsConfig;
 import com.chatalytics.core.json.JsonObjectMapperFactory;
+import com.chatalytics.web.constant.WebConstants;
 import com.chatalytics.web.utils.DateTimeUtils;
 import com.chatalytics.web.utils.ResourceUtils;
 import com.fasterxml.jackson.core.JsonGenerationException;
@@ -20,10 +21,10 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.util.Map;
 
-import javax.ws.rs.FormParam;
-import javax.ws.rs.POST;
+import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
@@ -36,7 +37,7 @@ import javax.ws.rs.core.Response;
 @Path(TopEmojisResource.EMOJI_ENDPOINT)
 public class TopEmojisResource {
 
-    public static final String EMOJI_ENDPOINT = "emoji";
+    public static final String EMOJI_ENDPOINT = WebConstants.API_PATH + "emoji";
     public static final String START_TIME_PARAM = "starttime";
     public static final String END_TIME_PARAM = "endtime";
     public static final String USER_PARAM = "user";
@@ -56,12 +57,12 @@ public class TopEmojisResource {
         objectMapper = JsonObjectMapperFactory.createObjectMapper(config.inputType);
     }
 
-    @POST
+    @GET
     @Produces(MediaType.APPLICATION_JSON)
-    public Response getTopEmojis(@FormParam(START_TIME_PARAM) String startTimeStr,
-                                 @FormParam(END_TIME_PARAM) String endTimeStr,
-                                 @FormParam(USER_PARAM) String user,
-                                 @FormParam(ROOM_PARAM) String room)
+    public Response getTopEmojis(@QueryParam(START_TIME_PARAM) String startTimeStr,
+                                 @QueryParam(END_TIME_PARAM) String endTimeStr,
+                                 @QueryParam(USER_PARAM) String user,
+                                 @QueryParam(ROOM_PARAM) String room)
                     throws JsonGenerationException, JsonMappingException, IOException {
 
         LOG.debug("Got query for starttime={}, endtime={}, user={}, room={}",

--- a/web/src/main/java/com/chatalytics/web/resources/TrendingTopicsResource.java
+++ b/web/src/main/java/com/chatalytics/web/resources/TrendingTopicsResource.java
@@ -4,6 +4,7 @@ import com.chatalytics.compute.db.dao.ChatAlyticsDAOFactory;
 import com.chatalytics.compute.db.dao.IEntityDAO;
 import com.chatalytics.core.config.ChatAlyticsConfig;
 import com.chatalytics.core.json.JsonObjectMapperFactory;
+import com.chatalytics.web.constant.WebConstants;
 import com.chatalytics.web.utils.DateTimeUtils;
 import com.chatalytics.web.utils.ResourceUtils;
 import com.fasterxml.jackson.core.JsonGenerationException;
@@ -20,10 +21,10 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.util.Map;
 
-import javax.ws.rs.FormParam;
-import javax.ws.rs.POST;
+import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
@@ -36,7 +37,7 @@ import javax.ws.rs.core.Response;
 @Path(TrendingTopicsResource.TRENDING_ENDPOINT)
 public class TrendingTopicsResource {
 
-    public static final String TRENDING_ENDPOINT = "trending";
+    public static final String TRENDING_ENDPOINT = WebConstants.API_PATH + "trending";
     public static final String START_TIME_PARAM = "starttime";
     public static final String END_TIME_PARAM = "endtime";
     public static final String USER_PARAM = "user";
@@ -55,12 +56,12 @@ public class TrendingTopicsResource {
         objectMapper = JsonObjectMapperFactory.createObjectMapper(config.inputType);
     }
 
-    @POST
+    @GET
     @Produces(MediaType.APPLICATION_JSON)
-    public Response getTrendingTopics(@FormParam(START_TIME_PARAM) String startTimeStr,
-                                      @FormParam(END_TIME_PARAM) String endTimeStr,
-                                      @FormParam(USER_PARAM) String user,
-                                      @FormParam(ROOM_PARAM) String room)
+    public Response getTrendingTopics(@QueryParam(START_TIME_PARAM) String startTimeStr,
+                                      @QueryParam(END_TIME_PARAM) String endTimeStr,
+                                      @QueryParam(USER_PARAM) String user,
+                                      @QueryParam(ROOM_PARAM) String room)
                     throws JsonGenerationException, JsonMappingException, IOException {
 
         LOG.debug("Got query for starttime={}, endtime={}, user={}, room={}",


### PR DESCRIPTION
- All the bolts were pulling the ChatAlyticsConfig from the storm conf. Create a base bolt that inherits from BaseRichBolt and that instantiates a ChatAlyticsConfig
- Adding a message summary bolt that emits message summary events to the realtime stream which is then exposes through the web servers realtime resource
- Changing all resources to use query params
- Changing all paths to use query params
- Close websocket connection immediately if not connected to compute

Closes #36 #32 #24
