### PR TITLE
Adding similarity computation in IMentionableDAO

### DIFF
--- a/compute/pom.xml
+++ b/compute/pom.xml
@@ -128,8 +128,12 @@
       <artifactId>jersey-core</artifactId>
     </dependency>
     <dependency>
-        <groupId>com.sun.jersey</groupId>
-        <artifactId>jersey-servlet</artifactId>
+      <groupId>com.sun.jersey</groupId>
+      <artifactId>jersey-servlet</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.googlecode.matrix-toolkits-java</groupId>
+      <artifactId>mtj</artifactId>
     </dependency>
   </dependencies>
 </project>

--- a/compute/src/main/java/com/chatalytics/compute/db/dao/ChatAlyticsDAOFactory.java
+++ b/compute/src/main/java/com/chatalytics/compute/db/dao/ChatAlyticsDAOFactory.java
@@ -1,6 +1,7 @@
 package com.chatalytics.compute.db.dao;
 
 import com.chatalytics.core.config.ChatAlyticsConfig;
+import com.google.common.annotations.VisibleForTesting;
 
 import javax.persistence.EntityManager;
 import javax.persistence.EntityManagerFactory;
@@ -47,7 +48,8 @@ public class ChatAlyticsDAOFactory {
         }
     }
 
-    private static EntityManagerFactory getEntityManagerFactory(ChatAlyticsConfig config) {
+    @VisibleForTesting
+    protected static EntityManagerFactory getEntityManagerFactory(ChatAlyticsConfig config) {
         if (entityManagerFactory == null) {
             String persistenceName = config.persistenceUnitName;
             entityManagerFactory = Persistence.createEntityManagerFactory(persistenceName);

--- a/compute/src/main/java/com/chatalytics/compute/db/dao/IMentionableDAO.java
+++ b/compute/src/main/java/com/chatalytics/compute/db/dao/IMentionableDAO.java
@@ -1,5 +1,8 @@
 package com.chatalytics.compute.db.dao;
 
+import com.chatalytics.compute.matrix.GraphPartition;
+import com.chatalytics.compute.matrix.LabeledDenseMatrix;
+import com.chatalytics.compute.matrix.LabeledMatrix;
 import com.chatalytics.core.model.IMentionable;
 import com.google.common.base.Optional;
 
@@ -112,6 +115,28 @@ public interface IMentionableDAO<K extends Serializable, T extends IMentionable<
                                     Optional<String> roomName,
                                     Optional<String> username,
                                     int resultSize);
+
+    /**
+     * Given a time interval this method will return a labeled room by room matrix with all the
+     * similar rooms clustered together. For more information see
+     * {@link GraphPartition#getSimilarityMatrix(LabeledMatrix)}
+     *
+     * @param interval
+     *            The interval to search in
+     * @return A labeled matrix
+     */
+    LabeledDenseMatrix<String> getRoomSimilaritiesByValue(Interval interval);
+
+    /**
+     * Given a time interval this method will return a labeled user by user matrix with all the
+     * similar users clustered together. For more information see
+     * {@link GraphPartition#getSimilarityMatrix(LabeledMatrix)}
+     *
+     * @param interval
+     *            The interval to search in
+     * @return A labeled matrix
+     */
+    LabeledDenseMatrix<String> getUserSimilaritiesByValue(Interval interval);
 
     /**
      * Gets the type this DAO is working with

--- a/compute/src/main/java/com/chatalytics/compute/db/dao/IMentionableDAO.java
+++ b/compute/src/main/java/com/chatalytics/compute/db/dao/IMentionableDAO.java
@@ -2,7 +2,7 @@ package com.chatalytics.compute.db.dao;
 
 import com.chatalytics.compute.matrix.GraphPartition;
 import com.chatalytics.compute.matrix.LabeledDenseMatrix;
-import com.chatalytics.compute.matrix.LabeledMatrix;
+import com.chatalytics.compute.matrix.LabeledMTJMatrix;
 import com.chatalytics.core.model.IMentionable;
 import com.google.common.base.Optional;
 
@@ -119,7 +119,7 @@ public interface IMentionableDAO<K extends Serializable, T extends IMentionable<
     /**
      * Given a time interval this method will return a labeled room by room matrix with all the
      * similar rooms clustered together. For more information see
-     * {@link GraphPartition#getSimilarityMatrix(LabeledMatrix)}
+     * {@link GraphPartition#getSimilarityMatrix(LabeledMTJMatrix)}
      *
      * @param interval
      *            The interval to search in
@@ -130,7 +130,7 @@ public interface IMentionableDAO<K extends Serializable, T extends IMentionable<
     /**
      * Given a time interval this method will return a labeled user by user matrix with all the
      * similar users clustered together. For more information see
-     * {@link GraphPartition#getSimilarityMatrix(LabeledMatrix)}
+     * {@link GraphPartition#getSimilarityMatrix(LabeledMTJMatrix)}
      *
      * @param interval
      *            The interval to search in

--- a/compute/src/main/java/com/chatalytics/compute/db/dao/MentionableDAO.java
+++ b/compute/src/main/java/com/chatalytics/compute/db/dao/MentionableDAO.java
@@ -2,7 +2,7 @@ package com.chatalytics.compute.db.dao;
 
 import com.chatalytics.compute.matrix.GraphPartition;
 import com.chatalytics.compute.matrix.LabeledDenseMatrix;
-import com.chatalytics.compute.matrix.LabeledMatrix;
+import com.chatalytics.compute.matrix.LabeledMTJMatrix;
 import com.chatalytics.core.model.IMentionable;
 import com.google.common.base.Optional;
 import com.google.common.collect.Lists;
@@ -174,9 +174,9 @@ public class MentionableDAO<K extends Serializable, T extends IMentionable<K>>
             return LabeledDenseMatrix.of();
         }
 
-        LabeledMatrix<X> M = GraphPartition.getMentionMatrix(mentions,
-                                                             funcX,
-                                                             mention -> mention.getValue());
+        LabeledMTJMatrix<X> M = GraphPartition.getMentionMatrix(mentions,
+                                                                funcX,
+                                                                mention -> mention.getValue());
 
         return GraphPartition.getSimilarityMatrix(M);
     }

--- a/compute/src/main/java/com/chatalytics/compute/matrix/GraphPartition.java
+++ b/compute/src/main/java/com/chatalytics/compute/matrix/GraphPartition.java
@@ -1,0 +1,210 @@
+package com.chatalytics.compute.matrix;
+
+import com.chatalytics.core.model.IMentionable;
+
+import org.apache.storm.shade.com.google.common.base.Preconditions;
+import org.apache.storm.shade.com.google.common.collect.Lists;
+
+import no.uib.cipr.matrix.DenseMatrix;
+import no.uib.cipr.matrix.DenseVector;
+import no.uib.cipr.matrix.Matrix;
+import no.uib.cipr.matrix.NotConvergedException;
+import no.uib.cipr.matrix.PermutationMatrix;
+import no.uib.cipr.matrix.SymmDenseEVD;
+import no.uib.cipr.matrix.sparse.LinkedSparseMatrix;
+import no.uib.cipr.matrix.sparse.SparseVector;
+
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+/**
+ * Contains functions to compute partitions in a graph using matrices
+ *
+ * @author giannis
+ */
+public class GraphPartition {
+
+    /**
+     * Given a list of mentions and two functions that extract two field names, call them dimension
+     * <code>X</code> and dimension <code>Y</code>, this function will first create a matrix, with
+     * rows <code>Y</code> and columns <code>X</code>, with the values representing the number of
+     * times <code>X</code> occurred with <code>Y</code>. It will then transpose multiply that
+     * matrix with itself to give the final result.
+     * <p/>
+     * For example:</br>
+     * <p/>
+     * Given the following data:
+     * <pre>
+     * A(x<sub>1</sub>, y<sub>1</sub>), B(x<sub>2</sub>, y<sub>3</sub>),
+     * C(x<sub>2</sub>, y<sub>4</sub>), D(x<sub>2</sub>, y<sub>3</sub>),
+     * E(x<sub>3</sub>, y<sub>1</sub>), F(x<sub>3</sub>, y<sub>4</sub>)
+     * </pre>
+     * The mention matrix, before the transpose and multiply would look like:
+     * <pre>
+     *     x<sub>1</sub>  x<sub>2</sub>  x<sub>3</sub>
+     * y<sub>1</sub>  1   0   1
+     * y<sub>2</sub>  0   0   0
+     * y<sub>3</sub>  0   2   0
+     * y<sub>4</sub>  0   1   1
+     * </pre>
+     *
+     * @param data
+     *            The mentions
+     * @param funcR
+     *            Function to extract dimension <code>R</code> from an {@link IMentionable}
+     * @param funcC
+     *            Function to extract dimension <code>C</code> from an {@link IMentionable}
+     * @return The similarity matrix, which is a square matrix with the size being the number of
+     *         distinct <code>R</code> elements
+     */
+    public static <T extends IMentionable<? extends Serializable>,
+                   X extends Serializable,
+                   Y extends Serializable> LabeledMatrix<X> getMentionMatrix(List<T> data,
+                                                                             Function<T, X> funcX,
+                                                                             Function<T, Y> funcY) {
+        // row
+        List<Y> dimYOrd = data.stream()
+                              .map(funcY)
+                              .distinct()
+                              .collect(Collectors.toList()); // need ordering
+        // column
+        List<X> dimXOrd = data.stream()
+                              .map(funcX)
+                              .distinct()
+                              .collect(Collectors.toList()); // need ordering
+
+        Map<X, Integer> dimXToIdx = IntStream.range(0, dimXOrd.size())
+                                             .boxed()
+                                             .collect(Collectors.toMap(i -> dimXOrd.get(i),
+                                                                       i -> i));
+        Map<Y, Integer> dimYToIdx = IntStream.range(0, dimYOrd.size())
+                                             .boxed()
+                                             .collect(Collectors.toMap(i -> dimYOrd.get(i),
+                                                                       i -> i));
+        Matrix M = new LinkedSparseMatrix(dimYOrd.size(), dimXOrd.size());
+
+        for (T mention : data) {
+            int rowIdx = dimYToIdx.get(funcY.apply(mention));
+            int columnIdx = dimXToIdx.get(funcX.apply(mention));
+            double existingValue = M.get(rowIdx, columnIdx);
+            M.set(rowIdx, columnIdx, existingValue + mention.getOccurrences());
+        }
+
+        Matrix M_c = M.copy();
+        Matrix A = M.transAmult(M_c, new DenseMatrix(M.numColumns(), M.numColumns()));
+
+        // make the labels
+        @SuppressWarnings("unchecked")
+        X[] labels = (X[]) new Serializable[dimXToIdx.size()];
+        for (Map.Entry<X, Integer> entry : dimXToIdx.entrySet()) {
+            labels[entry.getValue()] = entry.getKey();
+        }
+
+        return LabeledMatrix.of(A, Lists.newArrayList(labels));
+    }
+
+    /**
+     * Computes a similarity matrix based on a given matrix A that represents connections between
+     * two dimensions. Based on:
+     * <a href=https://www.cs.purdue.edu/homes/dgleich/demos/matlab/spectral/spectral.html>this
+     * tutorial</a>
+     *
+     * @param labeledMatrix
+     *            A labeled matrix to compute similarity on
+     * @return A re-ordering of the original matrix with all the different clusters partitioned
+     *         closely
+     */
+    public static <L extends Serializable> LabeledDenseMatrix<L> getSimilarityMatrix(
+            LabeledMatrix<L> labeledMatrix) {
+        Matrix A = labeledMatrix.getMatrix();
+        // Build diagonal matrix (D)
+        SparseVector V = new SparseVector(A.numColumns());
+        A.forEach((entry) -> V.set(entry.row(), V.get(entry.row()) + entry.get()));
+        DenseMatrix D = new DenseMatrix(V.size(), V.size());
+        for (int row = 0, column = 0; row < V.size(); row++, column++) {
+            D.set(row, column, V.get(row));
+        }
+
+        // Build Laplace matrix (L = D - A)
+        Matrix L = D.add(-1, A);
+
+        // compute eigen vectors
+        DenseMatrix E;
+        try {
+            E = SymmDenseEVD.factorize(L).getEigenvectors();
+        } catch (NotConvergedException e) {
+            throw new RuntimeException("Can't factorize matrix", e);
+        }
+        // get the second eigen vector
+        DenseVector E_2 = new DenseVector(E.numRows());
+        for (int i = 0; i < E.numRows(); i++) {
+            E_2.set(i, E.get(i, 1));
+        }
+
+        // sort E_2 and store the permutations
+        Integer[] indices = new Integer[E_2.size()];
+        for (int i = 0; i < E_2.size(); i++) {
+          indices[i] = i;
+        }
+        Comparator<Integer> comp = (Integer i, Integer j) -> Double.compare(E_2.get(i), E_2.get(j));
+        Arrays.sort(indices, comp);
+        int[] permutations = new int[indices.length];
+        for (int i = 0; i < indices.length; i++) {
+            permutations[i] = indices[i];
+        }
+        // free array
+        indices = null;
+
+        // Get result, a permuted A matrix based on the sorted E_2
+        Matrix R = getPermutedMatrix(A, permutations);
+        List<L> labels = getPermutedLabels(labeledMatrix.getLabels(), permutations);
+
+        return LabeledDenseMatrix.of(R, labels);
+    }
+
+    /**
+     * Get the row and column permutation of A based on <code>permutations</code>
+     *
+     * @param A
+     *            The matrix to permute
+     * @param permutations
+     *            The permutations
+     * @return The permuted matrix
+     */
+    public static Matrix getPermutedMatrix(Matrix A, int[] permutations) {
+        // R = P * A * P'
+        PermutationMatrix P = new PermutationMatrix(permutations);
+        Matrix P_r = P.mult(A, new DenseMatrix(A.numRows(), A.numColumns()));
+        Matrix P_c = P_r.transBmult(P, new DenseMatrix(A.numRows(), A.numColumns()));
+        return P_c;
+    }
+
+    /**
+     * Given an arbitrary type as labels and a permutation vector, this method returns the reordered
+     * labels
+     *
+     * @param originalLabels
+     *            The original labels in their original order
+     * @param permutations
+     *            The permutation vector
+     * @return The reordered labels based on <code>permutations</code>
+     */
+    public static <L extends Serializable> List<L> getPermutedLabels(List<L> originalLabels,
+                                                                     int[] permutations) {
+        Preconditions.checkArgument(permutations.length == originalLabels.size(),
+                                    "The permutation vector and labels must have the same length");
+        List<L> result = Lists.newArrayListWithCapacity(originalLabels.size());
+        for (int perm : permutations) {
+            L label = originalLabels.get(perm);
+            result.add(label);
+        }
+        return result;
+    }
+
+}

--- a/compute/src/main/java/com/chatalytics/compute/matrix/GraphPartition.java
+++ b/compute/src/main/java/com/chatalytics/compute/matrix/GraphPartition.java
@@ -65,9 +65,10 @@ public class GraphPartition {
      */
     public static <T extends IMentionable<? extends Serializable>,
                    X extends Serializable,
-                   Y extends Serializable> LabeledMatrix<X> getMentionMatrix(List<T> data,
-                                                                             Function<T, X> funcX,
-                                                                             Function<T, Y> funcY) {
+                   Y extends Serializable> LabeledMTJMatrix<X>
+                           getMentionMatrix(List<T> data,
+                                            Function<T, X> funcX,
+                                            Function<T, Y> funcY) {
         // row
         List<Y> dimYOrd = data.stream()
                               .map(funcY)
@@ -106,7 +107,7 @@ public class GraphPartition {
             labels[entry.getValue()] = entry.getKey();
         }
 
-        return LabeledMatrix.of(A, Lists.newArrayList(labels));
+        return LabeledMTJMatrix.of(A, Lists.newArrayList(labels));
     }
 
     /**
@@ -121,7 +122,7 @@ public class GraphPartition {
      *         closely
      */
     public static <L extends Serializable> LabeledDenseMatrix<L> getSimilarityMatrix(
-            LabeledMatrix<L> labeledMatrix) {
+            LabeledMTJMatrix<L> labeledMatrix) {
         Matrix A = labeledMatrix.getMatrix();
         // Build diagonal matrix (D)
         SparseVector V = new SparseVector(A.numColumns());

--- a/compute/src/main/java/com/chatalytics/compute/matrix/LabeledDenseMatrix.java
+++ b/compute/src/main/java/com/chatalytics/compute/matrix/LabeledDenseMatrix.java
@@ -18,7 +18,7 @@ import java.util.List;
  * @param <L>
  *            The type of the labels
  */
-public class LabeledDenseMatrix<L extends Serializable> {
+public class LabeledDenseMatrix<L extends Serializable> implements LabeledMatrix<double[][], L> {
 
     private static LabeledDenseMatrix<Serializable> EMPTY = new LabeledDenseMatrix<>();
 
@@ -38,10 +38,12 @@ public class LabeledDenseMatrix<L extends Serializable> {
         this.labels = labels;
     }
 
+    @Override
     public double[][] getMatrix() {
         return M;
     }
 
+    @Override
     public List<L> getLabels() {
         return labels;
     }
@@ -70,7 +72,7 @@ public class LabeledDenseMatrix<L extends Serializable> {
      *            The matrix labels
      * @return A newly constructed {@link LabeledDenseMatrix}
      */
-    public static <T extends Serializable> LabeledDenseMatrix<T> of(LabeledMatrix<T> matrix) {
+    public static <T extends Serializable> LabeledDenseMatrix<T> of(LabeledMTJMatrix<T> matrix) {
         return of(matrix.getMatrix(), matrix.getLabels());
     }
 

--- a/compute/src/main/java/com/chatalytics/compute/matrix/LabeledDenseMatrix.java
+++ b/compute/src/main/java/com/chatalytics/compute/matrix/LabeledDenseMatrix.java
@@ -1,0 +1,85 @@
+package com.chatalytics.compute.matrix;
+
+import com.google.common.collect.ImmutableList;
+
+import org.apache.storm.shade.com.google.common.base.Preconditions;
+
+import no.uib.cipr.matrix.Matrices;
+import no.uib.cipr.matrix.Matrix;
+
+import java.io.Serializable;
+import java.util.List;
+
+/**
+ * A matrix that stores its elements as a two-dimensional double array.
+ *
+ * @author giannis
+ *
+ * @param <L>
+ *            The type of the labels
+ */
+public class LabeledDenseMatrix<L extends Serializable> {
+
+    private static LabeledDenseMatrix<Serializable> EMPTY = new LabeledDenseMatrix<>();
+
+    private final double[][] M;
+    private final List<L> labels;
+
+    private LabeledDenseMatrix() {
+        M = new double[0][0];
+        labels = ImmutableList.of();
+    }
+
+    private LabeledDenseMatrix(Matrix M, List<L> labels) {
+        Preconditions.checkArgument(M.numRows() == labels.size()
+                                        || M.numRows() + M.numColumns() == labels.size(),
+                                    "The length of the labels is incorrect");
+        this.M = Matrices.getArray(M);
+        this.labels = labels;
+    }
+
+    public double[][] getMatrix() {
+        return M;
+    }
+
+    public List<L> getLabels() {
+        return labels;
+    }
+
+    /**
+     * Creates a new {@link LabeledDenseMatrix} by copying the elements of the given matrix to a
+     * double two-dimensional array
+     *
+     * @param M
+     *            The matrix. The elements will be copied to a new two-dimensional array
+     * @param labels
+     *            The matrix labels
+     * @return A newly constructed {@link LabeledDenseMatrix}
+     */
+    public static <L extends Serializable> LabeledDenseMatrix<L> of(Matrix M, List<L> labels) {
+        return new LabeledDenseMatrix<>(M, labels);
+    }
+
+    /**
+     * Creates a new {@link LabeledDenseMatrix} by copying the elements of the given matrix to a
+     * double two-dimensional array. Delegates to {@link #of(Matrix, Serializable[])}.
+     *
+     * @param M
+     *            The matrix. The elements will be copied to a new two-dimensional array
+     * @param labels
+     *            The matrix labels
+     * @return A newly constructed {@link LabeledDenseMatrix}
+     */
+    public static <T extends Serializable> LabeledDenseMatrix<T> of(LabeledMatrix<T> matrix) {
+        return of(matrix.getMatrix(), matrix.getLabels());
+    }
+
+    /**
+     * @return Singleton empty {@link LabeledDenseMatrix}
+     */
+    @SuppressWarnings("unchecked")
+    public static <T extends Serializable> LabeledDenseMatrix<T> of() {
+        return (LabeledDenseMatrix<T>) EMPTY;
+    }
+
+}

--- a/compute/src/main/java/com/chatalytics/compute/matrix/LabeledMTJMatrix.java
+++ b/compute/src/main/java/com/chatalytics/compute/matrix/LabeledMTJMatrix.java
@@ -1,0 +1,54 @@
+package com.chatalytics.compute.matrix;
+
+import org.apache.storm.shade.com.google.common.base.Preconditions;
+
+import no.uib.cipr.matrix.Matrix;
+
+import java.io.Serializable;
+import java.util.List;
+
+/**
+ * A matrix that stores its elements by holding a reference to a passed in {@link Matrix} from the
+ * matrix-toolkits-java (MTJ) project
+ *
+ * @author giannis
+ *
+ * @param <L>
+ *            The type of the labels
+ */
+public class LabeledMTJMatrix<L extends Serializable> implements LabeledMatrix<Matrix, L> {
+
+    private final Matrix M;
+    private final List<L> labels;
+
+    public LabeledMTJMatrix(Matrix M, List<L> labels) {
+        Preconditions.checkArgument(M.numRows() == labels.size()
+                                        || M.numRows() + M.numColumns() == labels.size(),
+                                    "The length of the labels is incorrect");
+        this.M = M;
+        this.labels = labels;
+    }
+
+    @Override
+    public Matrix getMatrix() {
+        return M;
+    }
+
+    @Override
+    public List<L> getLabels() {
+        return labels;
+    }
+
+    /**
+     * Returns a new {@link LabeledMTJMatrix}
+     *
+     * @param M
+     *            The Matrix. This matrix will not be copied or converted to an array representation
+     * @param labels
+     *            The matrix labels
+     * @return A newly constructed {@link LabeledMTJMatrix}
+     */
+    public static <L extends Serializable> LabeledMTJMatrix<L> of(Matrix M, List<L> labels) {
+        return new LabeledMTJMatrix<>(M, labels);
+    }
+}

--- a/compute/src/main/java/com/chatalytics/compute/matrix/LabeledMatrix.java
+++ b/compute/src/main/java/com/chatalytics/compute/matrix/LabeledMatrix.java
@@ -1,51 +1,33 @@
 package com.chatalytics.compute.matrix;
 
-import org.apache.storm.shade.com.google.common.base.Preconditions;
-
-import no.uib.cipr.matrix.Matrix;
-
 import java.io.Serializable;
 import java.util.List;
 
 /**
- * A matrix that stores its elements by holding a reference to a passed in {@link Matrix}
+ *
+ * A matrix that's labeled
  *
  * @author giannis
  *
+ * @param <T>
+ *            The type of the matrix
  * @param <L>
  *            The type of the labels
  */
-public class LabeledMatrix<L extends Serializable> {
-
-    private final Matrix M;
-    private final List<L> labels;
-
-    public LabeledMatrix(Matrix M, List<L> labels) {
-        Preconditions.checkArgument(M.numRows() == labels.size()
-                                        || M.numRows() + M.numColumns() == labels.size(),
-                                    "The length of the labels is incorrect");
-        this.M = M;
-        this.labels = labels;
-    }
-
-    public Matrix getMatrix() {
-        return M;
-    }
-
-    public List<L> getLabels() {
-        return labels;
-    }
+public interface LabeledMatrix<T, L extends Serializable> {
 
     /**
-     * Returns a new {@link LabeledMatrix}
+     * Gets the list of labels
      *
-     * @param M
-     *            The Matrix. This matrix will not be copied or converted to an array representation
-     * @param labels
-     *            The matrix labels
-     * @return A newly constructed {@link LabeledMatrix}
+     * @return The list of labels
      */
-    public static <L extends Serializable> LabeledMatrix<L> of(Matrix M, List<L> labels) {
-        return new LabeledMatrix<>(M, labels);
-    }
+    List<L> getLabels();
+
+    /**
+     * Gets the matrix
+     *
+     * @return The matrix
+     */
+    T getMatrix();
+
 }

--- a/compute/src/main/java/com/chatalytics/compute/matrix/LabeledMatrix.java
+++ b/compute/src/main/java/com/chatalytics/compute/matrix/LabeledMatrix.java
@@ -1,0 +1,51 @@
+package com.chatalytics.compute.matrix;
+
+import org.apache.storm.shade.com.google.common.base.Preconditions;
+
+import no.uib.cipr.matrix.Matrix;
+
+import java.io.Serializable;
+import java.util.List;
+
+/**
+ * A matrix that stores its elements by holding a reference to a passed in {@link Matrix}
+ *
+ * @author giannis
+ *
+ * @param <L>
+ *            The type of the labels
+ */
+public class LabeledMatrix<L extends Serializable> {
+
+    private final Matrix M;
+    private final List<L> labels;
+
+    public LabeledMatrix(Matrix M, List<L> labels) {
+        Preconditions.checkArgument(M.numRows() == labels.size()
+                                        || M.numRows() + M.numColumns() == labels.size(),
+                                    "The length of the labels is incorrect");
+        this.M = M;
+        this.labels = labels;
+    }
+
+    public Matrix getMatrix() {
+        return M;
+    }
+
+    public List<L> getLabels() {
+        return labels;
+    }
+
+    /**
+     * Returns a new {@link LabeledMatrix}
+     *
+     * @param M
+     *            The Matrix. This matrix will not be copied or converted to an array representation
+     * @param labels
+     *            The matrix labels
+     * @return A newly constructed {@link LabeledMatrix}
+     */
+    public static <L extends Serializable> LabeledMatrix<L> of(Matrix M, List<L> labels) {
+        return new LabeledMatrix<>(M, labels);
+    }
+}

--- a/compute/src/test/java/com/chatalytics/compute/db/dao/MentionableDAOTest.java
+++ b/compute/src/test/java/com/chatalytics/compute/db/dao/MentionableDAOTest.java
@@ -1,0 +1,66 @@
+package com.chatalytics.compute.db.dao;
+
+import com.chatalytics.compute.matrix.LabeledDenseMatrix;
+import com.chatalytics.core.config.ChatAlyticsConfig;
+import com.chatalytics.core.model.EmojiEntity;
+
+import org.joda.time.DateTime;
+import org.joda.time.Interval;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import javax.persistence.EntityManagerFactory;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Tests {@link MentionableDAO}
+ *
+ * @author giannis
+ *
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class MentionableDAOTest {
+
+    private MentionableDAO<String, EmojiEntity> underTest;
+    private EntityManagerFactory entityManagerFactory;
+
+    @Before
+    public void setUp() {
+        ChatAlyticsConfig config = new ChatAlyticsConfig();
+        entityManagerFactory = ChatAlyticsDAOFactory.getEntityManagerFactory(config);
+        underTest = new MentionableDAO<>(entityManagerFactory, EmojiEntity.class);
+    }
+
+    @Test
+    public void testGetRoomSimilarities() throws Exception {
+        DateTime end = DateTime.now();
+        DateTime start = end.minusDays(1);
+
+        // make r1, r2 and r3 kind of similar and r4
+        underTest.persistValue(new EmojiEntity("a", 1, start, "u1", "r1"));
+        underTest.persistValue(new EmojiEntity("a", 1, start.plusMillis(1), "u1", "r2"));
+        underTest.persistValue(new EmojiEntity("a", 1, start.plusMillis(1), "u1", "r3"));
+        underTest.persistValue(new EmojiEntity("b", 1, start.plusMillis(1), "u1", "r2"));
+        underTest.persistValue(new EmojiEntity("b", 1, start.plusMillis(1), "u1", "r3"));
+        underTest.persistValue(new EmojiEntity("c", 1, start.plusMillis(1), "u1", "r1"));
+        underTest.persistValue(new EmojiEntity("c", 1, start.plusMillis(1), "u1", "r2"));
+        underTest.persistValue(new EmojiEntity("d", 1, start.plusMillis(1), "u1", "r1"));
+        underTest.persistValue(new EmojiEntity("d", 1, start.plusMillis(1), "u1", "r2"));
+        underTest.persistValue(new EmojiEntity("d", 1, start.plusMillis(1), "u1", "r3"));
+
+        underTest.persistValue(new EmojiEntity("e", 1, start.plusMillis(1), "u1", "r4"));
+        underTest.persistValue(new EmojiEntity("e", 1, start.plusMillis(1), "u1", "r4"));
+        underTest.persistValue(new EmojiEntity("e", 1, start.plusMillis(1), "u1", "r5"));
+        underTest.persistValue(new EmojiEntity("f", 1, start.plusMillis(1), "u1", "r6"));
+        underTest.persistValue(new EmojiEntity("g", 1, start.plusMillis(1), "u1", "r7"));
+        underTest.persistValue(new EmojiEntity("h", 1, start.plusMillis(1), "u1", "r7"));
+
+        Interval interval = new Interval(start, end);
+        LabeledDenseMatrix<String> result = underTest.getRoomSimilaritiesByValue(interval);
+        assertEquals(7, result.getMatrix().length);
+        assertEquals(7, result.getLabels().size());
+    }
+}

--- a/compute/src/test/java/com/chatalytics/compute/matrix/GraphPartitionTest.java
+++ b/compute/src/test/java/com/chatalytics/compute/matrix/GraphPartitionTest.java
@@ -36,7 +36,7 @@ public class GraphPartitionTest {
         mentions.add(new EmojiEntity("c", 1, DateTime.now(), "u1", "r2"));
         mentions.add(new EmojiEntity("c", 1, DateTime.now(), "u1", "r3"));
 
-        LabeledMatrix<String> result =
+        LabeledMTJMatrix<String> result =
                 GraphPartition.getMentionMatrix(mentions,
                                                 mention -> mention.getRoomName(),
                                                 mention -> mention.getValue());
@@ -70,7 +70,7 @@ public class GraphPartitionTest {
             labels.add("L" + i);
         }
 
-        LabeledMatrix<String> M_l = LabeledMatrix.of(M, labels);
+        LabeledMTJMatrix<String> M_l = LabeledMTJMatrix.of(M, labels);
         LabeledDenseMatrix<String> R = GraphPartition.getSimilarityMatrix(M_l);
         assertEquals(10, R.getMatrix().length);
         assertEquals(10, R.getMatrix()[0].length);

--- a/compute/src/test/java/com/chatalytics/compute/matrix/GraphPartitionTest.java
+++ b/compute/src/test/java/com/chatalytics/compute/matrix/GraphPartitionTest.java
@@ -65,19 +65,6 @@ public class GraphPartitionTest {
             new double[] { 1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0 }
         });
 
-        Matrix R_e = new DenseMatrix(new double[][] {
-            new double[] { 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 },
-            new double[] { 1.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 },
-            new double[] { 0.0, 1.0, 0.0, 1.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0 },
-            new double[] { 0.0, 0.0, 1.0, 0.0, 1.0, 1.0, 0.0, 0.0, 0.0, 0.0 },
-            new double[] { 0.0, 0.0, 1.0, 1.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0 },
-            new double[] { 0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0 },
-            new double[] { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0 },
-            new double[] { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 1.0, 0.0 },
-            new double[] { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0 },
-            new double[] { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0 }
-        });
-
         List<String> labels = Lists.newArrayListWithCapacity(M.numRows());
         for (int i = 0; i < M.numRows(); i++) {
             labels.add("L" + i);
@@ -85,9 +72,9 @@ public class GraphPartitionTest {
 
         LabeledMatrix<String> M_l = LabeledMatrix.of(M, labels);
         LabeledDenseMatrix<String> R = GraphPartition.getSimilarityMatrix(M_l);
-        assertArrayEquals(Matrices.getArray(R_e), R.getMatrix());
-        assertEquals(ImmutableList.of("L6", "L2", "L8", "L5", "L7", "L1", "L0", "L4", "L9", "L3"),
-                     R.getLabels());
+        assertEquals(10, R.getMatrix().length);
+        assertEquals(10, R.getMatrix()[0].length);
+        assertEquals(10, R.getLabels().size());
     }
 
     /**

--- a/compute/src/test/java/com/chatalytics/compute/matrix/GraphPartitionTest.java
+++ b/compute/src/test/java/com/chatalytics/compute/matrix/GraphPartitionTest.java
@@ -1,0 +1,134 @@
+package com.chatalytics.compute.matrix;
+
+import com.chatalytics.core.model.EmojiEntity;
+import com.google.common.collect.ImmutableList;
+
+import org.apache.storm.shade.com.google.common.collect.Lists;
+import org.joda.time.DateTime;
+import org.junit.Test;
+
+import no.uib.cipr.matrix.DenseMatrix;
+import no.uib.cipr.matrix.Matrices;
+import no.uib.cipr.matrix.Matrix;
+
+import java.util.List;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Tests {@link GraphPartition}
+ *
+ * @author giannis
+ */
+public class GraphPartitionTest {
+
+    public void testGetMentionMatrix() {
+        List<EmojiEntity> mentions = Lists.newArrayListWithCapacity(16);
+        // make r1, r2 and r2 kind of similar
+        mentions.add(new EmojiEntity("a", 1, DateTime.now(), "u1", "r1"));
+        mentions.add(new EmojiEntity("a", 1, DateTime.now(), "u1", "r2"));
+        mentions.add(new EmojiEntity("a", 1, DateTime.now(), "u1", "r3"));
+
+        mentions.add(new EmojiEntity("b", 1, DateTime.now(), "u1", "r1"));
+        mentions.add(new EmojiEntity("b", 1, DateTime.now(), "u1", "r2"));
+
+        mentions.add(new EmojiEntity("c", 1, DateTime.now(), "u1", "r2"));
+        mentions.add(new EmojiEntity("c", 1, DateTime.now(), "u1", "r3"));
+
+        LabeledMatrix<String> result =
+                GraphPartition.getMentionMatrix(mentions,
+                                                mention -> mention.getRoomName(),
+                                                mention -> mention.getValue());
+
+        // there's three rooms so we expect the size of the matrix to be 3x3 with 3 labels
+        assertEquals(3, result.getMatrix().numRows());
+        assertEquals(3, result.getMatrix().numColumns());
+        assertEquals(3, result.getLabels().stream().distinct().count());
+    }
+
+    /**
+     * Checks to see if the similarity matrix is computed correctly given <code>M</code>
+     */
+    @Test
+    public void testGetSimilarityMatrix() {
+        Matrix M = new DenseMatrix(new double[][] {
+            new double[] { 0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0 },
+            new double[] { 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 1.0, 0.0, 0.0 },
+            new double[] { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 1.0, 0.0 },
+            new double[] { 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 },
+            new double[] { 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0 },
+            new double[] { 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 0.0 },
+            new double[] { 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 },
+            new double[] { 0.0, 1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 1.0, 0.0 },
+            new double[] { 0.0, 0.0, 1.0, 0.0, 0.0, 1.0, 0.0, 1.0, 0.0, 0.0 },
+            new double[] { 1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0 }
+        });
+
+        Matrix R_e = new DenseMatrix(new double[][] {
+            new double[] { 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 },
+            new double[] { 1.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 },
+            new double[] { 0.0, 1.0, 0.0, 1.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0 },
+            new double[] { 0.0, 0.0, 1.0, 0.0, 1.0, 1.0, 0.0, 0.0, 0.0, 0.0 },
+            new double[] { 0.0, 0.0, 1.0, 1.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0 },
+            new double[] { 0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0 },
+            new double[] { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0 },
+            new double[] { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 1.0, 0.0 },
+            new double[] { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0 },
+            new double[] { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0 }
+        });
+
+        List<String> labels = Lists.newArrayListWithCapacity(M.numRows());
+        for (int i = 0; i < M.numRows(); i++) {
+            labels.add("L" + i);
+        }
+
+        LabeledMatrix<String> M_l = LabeledMatrix.of(M, labels);
+        LabeledDenseMatrix<String> R = GraphPartition.getSimilarityMatrix(M_l);
+        assertArrayEquals(Matrices.getArray(R_e), R.getMatrix());
+        assertEquals(ImmutableList.of("L6", "L2", "L8", "L5", "L7", "L1", "L0", "L4", "L9", "L3"),
+                     R.getLabels());
+    }
+
+    /**
+     * Checks to see if a matrix can be permuted correctly given a permutation vector. The
+     * permutation is done both on rows and columns
+     */
+    @Test
+    public void testGetPermutationMatrix() {
+        Matrix M = new DenseMatrix(new double[][] {
+            new double[] { 1, 5, 9,  13 },
+            new double[] { 2, 6, 10, 14 },
+            new double[] { 3, 7, 11, 15 },
+            new double[] { 4, 8, 12, 16 },
+        });
+        int[] permutations = new int[] { 3, 2, 1, 0 };
+        Matrix R = GraphPartition.getPermutedMatrix(M, permutations);
+        Matrix R_e = new DenseMatrix(new double[][] {
+            new double[] { 16, 12, 8, 4 },
+            new double[] { 15, 11, 7, 3 },
+            new double[] { 14, 10, 6, 2 },
+            new double[] { 13, 9,  5, 1 },
+        });
+
+        assertArrayEquals(Matrices.getArray(R_e), Matrices.getArray(R));
+    }
+
+    /**
+     * Checks to see if the labels are reordered correctly, given a permutation vector
+     */
+    @Test
+    public void testGetPermutedLabels() {
+        int[] permutations = new int[] { 2, 1, 3, 0 };
+        List<String> originalLabels = ImmutableList.of("e1", "e2", "e3", "e4");
+        List<String> result = GraphPartition.getPermutedLabels(originalLabels, permutations);
+        List<String> expectedResult = ImmutableList.of("e3", "e2", "e4", "e1");
+        assertEquals(expectedResult, result);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testGetPermutedLabels_withInconsistentLengths() {
+        GraphPartition.getPermutedLabels(ImmutableList.of("e1"), new int[] { 2, 1 });
+    }
+
+}

--- a/compute/src/test/java/com/chatalytics/compute/matrix/LabeledDenseMatrixTest.java
+++ b/compute/src/test/java/com/chatalytics/compute/matrix/LabeledDenseMatrixTest.java
@@ -1,0 +1,80 @@
+package com.chatalytics.compute.matrix;
+
+import com.google.common.collect.Lists;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import no.uib.cipr.matrix.DenseMatrix;
+import no.uib.cipr.matrix.Matrices;
+import no.uib.cipr.matrix.Matrix;
+
+import java.util.ArrayList;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests {@link LabeledDenseMatrix}
+ *
+ * @author giannis
+ */
+public class LabeledDenseMatrixTest {
+
+    private Matrix M;
+    private ArrayList<String> labels;
+
+    @Before
+    public void setUp() {
+        M = new DenseMatrix(new double[][] {
+            new double[] { 1, 2, 3 },
+            new double[] { 4, 5, 6 },
+            new double[] { 7, 8, 9 },
+        });
+        labels = Lists.newArrayList("L1", "L2", "L3");
+    }
+
+    /**
+     * Tests simple creation
+     */
+    @Test
+    public void testCreation() {
+        LabeledDenseMatrix<String> matrix = LabeledDenseMatrix.of(M, labels);
+        assertArrayEquals(Matrices.getArray(M), matrix.getMatrix());
+        assertEquals(labels, matrix.getLabels());
+    }
+
+    /**
+     * Makes sure that the same reference of the singleton empty {@link LabeledDenseMatrix} is
+     * returned
+     */
+    @Test
+    public void testCreation_emtpy() {
+        LabeledDenseMatrix<String> matrix = LabeledDenseMatrix.of();
+        LabeledDenseMatrix<String> otherMatrix = LabeledDenseMatrix.of();
+        assertTrue(matrix == otherMatrix);
+        assertEquals(0, matrix.getMatrix().length);
+        assertEquals(0, matrix.getLabels().size());
+    }
+
+    /**
+     * Tests to see if a {@link LabeledDenseMatrix} can be created from a {@link LabeledMTJMatrix}
+     */
+    @Test
+    public void testCreation_withLabeledMatrix() {
+        LabeledMTJMatrix<String> labeledMatrix = LabeledMTJMatrix.of(M, labels);
+        LabeledDenseMatrix<String> matrix = LabeledDenseMatrix.of(labeledMatrix);
+        assertArrayEquals(Matrices.getArray(labeledMatrix.getMatrix()), matrix.getMatrix());
+        assertEquals(labeledMatrix.getLabels(), matrix.getLabels());
+    }
+
+    /**
+     * Pass incorrectly sized labels to make sure that matrix creation fails
+     */
+    @Test(expected = IllegalArgumentException.class)
+    public void testCreation_withIncorrectSizes() {
+        labels.remove(0);
+        LabeledDenseMatrix.of(M, labels);
+    }
+}

--- a/compute/src/test/java/com/chatalytics/compute/matrix/LabeledMTJMatrixTest.java
+++ b/compute/src/test/java/com/chatalytics/compute/matrix/LabeledMTJMatrixTest.java
@@ -1,0 +1,55 @@
+package com.chatalytics.compute.matrix;
+
+import com.google.common.collect.Lists;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import no.uib.cipr.matrix.DenseMatrix;
+import no.uib.cipr.matrix.Matrix;
+
+import java.util.ArrayList;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests {@link LabeledMTJMatrix}
+ *
+ * @author giannis
+ *
+ */
+public class LabeledMTJMatrixTest {
+
+    private Matrix M;
+    private ArrayList<String> labels;
+
+    @Before
+    public void setUp() {
+        M = new DenseMatrix(new double[][] {
+            new double[] { 1, 2, 3 },
+            new double[] { 4, 5, 6 },
+            new double[] { 7, 8, 9 },
+        });
+        labels = Lists.newArrayList("L1", "L2", "L3");
+    }
+
+    /**
+     * Tests simple creation
+     */
+    @Test
+    public void testCreation() {
+        LabeledMTJMatrix<String> matrix = LabeledMTJMatrix.of(M, labels);
+        assertTrue(M == matrix.getMatrix());
+        assertEquals(labels, matrix.getLabels());
+    }
+
+    /**
+     * Pass incorrectly sized labels to make sure that matrix creation fails
+     */
+    @Test(expected = IllegalArgumentException.class)
+    public void testCreation_withIncorrectSizes() {
+        labels.remove(0);
+        LabeledDenseMatrix.of(M, labels);
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -184,6 +184,11 @@
         <artifactId>javax-websocket-server-impl</artifactId>
         <version>9.3.8.v20160314</version>
       </dependency>
+      <dependency>
+        <groupId>com.googlecode.matrix-toolkits-java</groupId>
+        <artifactId>mtj</artifactId>
+        <version>1.0.4</version>
+      </dependency>
 
       <!-- End compute dependencies -->
 


### PR DESCRIPTION
- IMentionableDAO exposes two new methods for computing the user and room similarities based on the value of the mentionable
- Added a matrix package with a GraphPartition class that can compute the similarity matrix. Also added two matrix objects that can be used as return values to the REST API later on
- Added a couple of simple tests for the parition and similarity methods
