### PR TITLE
Adding message types, several DAO/spout bug fixes

### DIFF
--- a/compute/src/main/java/com/chatalytics/compute/realtime/RealtimeResource.java
+++ b/compute/src/main/java/com/chatalytics/compute/realtime/RealtimeResource.java
@@ -5,7 +5,6 @@ import com.chatalytics.core.realtime.ChatAlyticsEventDecoder;
 import com.chatalytics.core.realtime.ChatAlyticsEventEncoder;
 import com.chatalytics.core.realtime.ConnectionType;
 import com.chatalytics.core.realtime.ConnectionTypeEncoderDecoder;
-import com.google.common.base.Throwables;
 import com.google.common.collect.Sets;
 
 import org.slf4j.Logger;
@@ -71,6 +70,7 @@ public class RealtimeResource {
 
             sessions.add(session);
         } else {
+//            session.setMaxIdleTimeout(Long.MAX_VALUE);
             LOG.info("Got a new publisher connection request with ID {}", session.getId());
         }
     }
@@ -116,7 +116,7 @@ public class RealtimeResource {
      */
     @OnError
     public void onError(Throwable t) {
-        LOG.error(Throwables.getStackTraceAsString(t));
+        LOG.error("Uncought exception in realtime resource", t);
     }
 
 }

--- a/compute/src/main/java/com/chatalytics/compute/storm/bolt/EmojiCounterBolt.java
+++ b/compute/src/main/java/com/chatalytics/compute/storm/bolt/EmojiCounterBolt.java
@@ -9,6 +9,7 @@ import com.chatalytics.core.model.Room;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Maps;
 
+import org.apache.storm.shade.com.google.common.collect.ImmutableList;
 import org.apache.storm.shade.com.google.common.collect.Lists;
 import org.apache.storm.task.OutputCollector;
 import org.apache.storm.task.TopologyContext;
@@ -56,6 +57,11 @@ public class EmojiCounterBolt extends ChatAlyticsBaseBolt {
     @VisibleForTesting
     protected List<EmojiEntity> getEmojisFromMessage(FatMessage fatMessage) {
         String message = fatMessage.getMessage().getMessage();
+
+        if (message == null) {
+            return ImmutableList.of();
+        }
+
         Map<String, EmojiEntity> emojis = Maps.newHashMap();
 
         OfInt charIterator = message.chars().iterator();
@@ -118,6 +124,12 @@ public class EmojiCounterBolt extends ChatAlyticsBaseBolt {
     @Override
     public void declareOutputFields(OutputFieldsDeclarer fields) {
         fields.declare(new Fields(EMOJI_ENTITY_FIELD_STR));
+    }
+
+    @Override
+    public void cleanup() {
+        LOG.debug("Cleaning up {}", this.getClass().getSimpleName());
+        emojiDao.stopAsync().awaitTerminated();
     }
 
 }

--- a/compute/src/main/java/com/chatalytics/compute/storm/bolt/EntityExtractionBolt.java
+++ b/compute/src/main/java/com/chatalytics/compute/storm/bolt/EntityExtractionBolt.java
@@ -12,6 +12,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.io.Resources;
 
+import org.apache.storm.shade.com.google.common.collect.ImmutableList;
 import org.apache.storm.task.OutputCollector;
 import org.apache.storm.task.TopologyContext;
 import org.apache.storm.topology.OutputFieldsDeclarer;
@@ -102,6 +103,10 @@ public class EntityExtractionBolt extends ChatAlyticsBaseBolt {
         Message message = fatMessage.getMessage();
         String messageStr = message.getMessage();
 
+        if (messageStr == null) {
+            return ImmutableList.of();
+        }
+
         List<Triple<String,Integer,Integer>> classification =
                 classifier.classifyToCharacterOffsets(messageStr);
         Map<String, ChatEntity> entities = Maps.newHashMapWithExpectedSize(classification.size());
@@ -145,6 +150,7 @@ public class EntityExtractionBolt extends ChatAlyticsBaseBolt {
 
     @Override
     public void cleanup() {
+        LOG.debug("Cleaning up {}", this.getClass().getSimpleName());
         entityDao.stopAsync().awaitTerminated();
     }
 

--- a/compute/src/main/java/com/chatalytics/compute/storm/bolt/MessageSummaryBolt.java
+++ b/compute/src/main/java/com/chatalytics/compute/storm/bolt/MessageSummaryBolt.java
@@ -3,6 +3,7 @@ package com.chatalytics.compute.storm.bolt;
 import com.chatalytics.core.config.ChatAlyticsConfig;
 import com.chatalytics.core.model.FatMessage;
 import com.chatalytics.core.model.MessageSummary;
+import com.chatalytics.core.model.MessageType;
 
 import org.apache.storm.task.OutputCollector;
 import org.apache.storm.task.TopologyContext;
@@ -46,7 +47,8 @@ public class MessageSummaryBolt extends ChatAlyticsBaseBolt {
             roomName = fatMessage.getRoom().getName();
         }
         DateTime messageDate = fatMessage.getMessage().getDate();
-        MessageSummary chatSummary = new MessageSummary(username, roomName, messageDate);
+        MessageType type = fatMessage.getMessage().getType();
+        MessageSummary chatSummary = new MessageSummary(username, roomName, messageDate, type);
         collector.emit(new Values(chatSummary));
     }
 

--- a/compute/src/main/java/com/chatalytics/compute/storm/bolt/RealtimeBolt.java
+++ b/compute/src/main/java/com/chatalytics/compute/storm/bolt/RealtimeBolt.java
@@ -112,4 +112,14 @@ public class RealtimeBolt extends ChatAlyticsBaseBolt {
     public void declareOutputFields(OutputFieldsDeclarer fields) {
         // no output
     }
+
+    @Override
+    public void cleanup() {
+        LOG.debug("Cleaning up {}", this.getClass().getSimpleName());
+        try {
+            session.close();
+        } catch (IOException e) {
+            LOG.warn("Unable to close session. Reason: {}", e.getMessage());
+        }
+    }
 }

--- a/compute/src/main/java/com/chatalytics/compute/storm/spout/LocalTestSpout.java
+++ b/compute/src/main/java/com/chatalytics/compute/storm/spout/LocalTestSpout.java
@@ -7,6 +7,7 @@ import com.chatalytics.core.config.ChatAlyticsConfig;
 import com.chatalytics.core.config.LocalTestConfig;
 import com.chatalytics.core.model.FatMessage;
 import com.chatalytics.core.model.Message;
+import com.chatalytics.core.model.MessageType;
 import com.chatalytics.core.model.Room;
 import com.chatalytics.core.model.User;
 import com.google.common.collect.Lists;
@@ -61,7 +62,8 @@ public class LocalTestSpout extends BaseRichSpout {
         String messageStr = sentences.get(rand.nextInt(sentences.size()));
 
         Message message = new Message(DateTime.now(dtZone), fromUser.getName(),
-                                      fromUser.getUserId(), messageStr, room.getRoomId());
+                                      fromUser.getUserId(), messageStr, room.getRoomId(),
+                                      MessageType.MESSAGE);
 
         FatMessage fatMessage = new FatMessage(message, fromUser, room);
 
@@ -132,7 +134,7 @@ public class LocalTestSpout extends BaseRichSpout {
             String name = String.format("name-%s", namePostfix);
             String mentionName = RandomStringUtils.generateRandomAlphaNumericString(6, rand);
 
-            User randomUser = new User(userId, email, false, false, name, mentionName, null,
+            User randomUser = new User(userId, email, false, false, false, name, mentionName, null,
                                        DateTime.now(DateTimeZone.UTC),
                                        DateTime.now(DateTimeZone.UTC), null, null, "UTC", null);
 

--- a/compute/src/main/java/com/chatalytics/compute/storm/spout/SlackMessageSpout.java
+++ b/compute/src/main/java/com/chatalytics/compute/storm/spout/SlackMessageSpout.java
@@ -8,6 +8,7 @@ import com.chatalytics.compute.util.YamlUtils;
 import com.chatalytics.core.config.ChatAlyticsConfig;
 import com.chatalytics.core.model.FatMessage;
 import com.chatalytics.core.model.Message;
+import com.chatalytics.core.model.MessageType;
 import com.chatalytics.core.model.Room;
 import com.chatalytics.core.model.User;
 import com.google.common.annotations.VisibleForTesting;
@@ -20,6 +21,7 @@ import org.apache.storm.topology.base.BaseRichSpout;
 import org.apache.storm.tuple.Fields;
 import org.apache.storm.tuple.Values;
 import org.glassfish.tyrus.container.jdk.client.JdkContainerProvider;
+import org.joda.time.DateTime;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -141,6 +143,11 @@ public class SlackMessageSpout extends BaseRichSpout {
         Map<String, Room> rooms = slackDao.getRooms();
 
         User fromUser = users.get(message.getFromUserId());
+        if (fromUser == null && message.getType() == MessageType.BOT_MESSAGE) {
+            fromUser = new User(message.getFromUserId(), null, false, false, true,
+                                message.getFromName(), message.getFromName(), null, DateTime.now(),
+                                null, null, null, null, null);
+        }
         Room room = rooms.get(message.getRoomId());
 
         FatMessage fatMessage = new FatMessage(message, fromUser, room);

--- a/compute/src/test/java/com/chatalytics/compute/db/dao/MentionableDAOTest.java
+++ b/compute/src/test/java/com/chatalytics/compute/db/dao/MentionableDAOTest.java
@@ -14,6 +14,8 @@ import org.mockito.runners.MockitoJUnitRunner;
 import javax.persistence.EntityManagerFactory;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 
 /**
  * Tests {@link MentionableDAO}
@@ -41,26 +43,39 @@ public class MentionableDAOTest {
 
         // make r1, r2 and r3 kind of similar and r4
         underTest.persistValue(new EmojiEntity("a", 1, start, "u1", "r1"));
-        underTest.persistValue(new EmojiEntity("a", 1, start.plusMillis(1), "u1", "r2"));
-        underTest.persistValue(new EmojiEntity("a", 1, start.plusMillis(1), "u1", "r3"));
-        underTest.persistValue(new EmojiEntity("b", 1, start.plusMillis(1), "u1", "r2"));
-        underTest.persistValue(new EmojiEntity("b", 1, start.plusMillis(1), "u1", "r3"));
-        underTest.persistValue(new EmojiEntity("c", 1, start.plusMillis(1), "u1", "r1"));
-        underTest.persistValue(new EmojiEntity("c", 1, start.plusMillis(1), "u1", "r2"));
-        underTest.persistValue(new EmojiEntity("d", 1, start.plusMillis(1), "u1", "r1"));
-        underTest.persistValue(new EmojiEntity("d", 1, start.plusMillis(1), "u1", "r2"));
-        underTest.persistValue(new EmojiEntity("d", 1, start.plusMillis(1), "u1", "r3"));
+        underTest.persistValue(new EmojiEntity("a", 2, start.plusMillis(1), "u1", "r2"));
+        underTest.persistValue(new EmojiEntity("a", 3, start.plusMillis(1), "u1", "r3"));
+        underTest.persistValue(new EmojiEntity("b", 4, start.plusMillis(1), "u1", "r2"));
+        underTest.persistValue(new EmojiEntity("b", 5, start.plusMillis(1), "u1", "r3"));
+        underTest.persistValue(new EmojiEntity("c", 6, start.plusMillis(1), "u1", "r1"));
+        underTest.persistValue(new EmojiEntity("c", 7, start.plusMillis(1), "u1", "r2"));
+        underTest.persistValue(new EmojiEntity("d", 8, start.plusMillis(1), "u1", "r1"));
+        underTest.persistValue(new EmojiEntity("d", 9, start.plusMillis(1), "u1", "r2"));
+        underTest.persistValue(new EmojiEntity("d", 10, start.plusMillis(1), "u1", "r3"));
 
-        underTest.persistValue(new EmojiEntity("e", 1, start.plusMillis(1), "u1", "r4"));
-        underTest.persistValue(new EmojiEntity("e", 1, start.plusMillis(1), "u1", "r4"));
-        underTest.persistValue(new EmojiEntity("e", 1, start.plusMillis(1), "u1", "r5"));
-        underTest.persistValue(new EmojiEntity("f", 1, start.plusMillis(1), "u1", "r6"));
-        underTest.persistValue(new EmojiEntity("g", 1, start.plusMillis(1), "u1", "r7"));
-        underTest.persistValue(new EmojiEntity("h", 1, start.plusMillis(1), "u1", "r7"));
+        underTest.persistValue(new EmojiEntity("e", 11, start.plusMillis(1), "u1", "r4"));
+        underTest.persistValue(new EmojiEntity("e", 12, start.plusMillis(1), "u1", "r4"));
+        underTest.persistValue(new EmojiEntity("e", 13, start.plusMillis(1), "u1", "r5"));
+        underTest.persistValue(new EmojiEntity("f", 14, start.plusMillis(1), "u1", "r6"));
+        underTest.persistValue(new EmojiEntity("g", 15, start.plusMillis(1), "u1", "r7"));
+        underTest.persistValue(new EmojiEntity("h", 16, start.plusMillis(1), "u1", "r7"));
 
         Interval interval = new Interval(start, end);
         LabeledDenseMatrix<String> result = underTest.getRoomSimilaritiesByValue(interval);
         assertEquals(7, result.getMatrix().length);
         assertEquals(7, result.getLabels().size());
+    }
+
+    @Test
+    public void testPersistValue() {
+        DateTime dateTime = DateTime.now();
+        EmojiEntity emoji = new EmojiEntity("a", 1, dateTime, "u1", "r1");
+        assertNull(underTest.getValue(emoji));
+        underTest.persistValue(emoji);
+        assertNotNull(underTest.getValue(emoji));
+
+        // store it again and make sure an exception is not thrown
+        underTest.persistValue(emoji);
+        assertNotNull(underTest.getValue(emoji));
     }
 }

--- a/compute/src/test/java/com/chatalytics/compute/storm/bolt/EmojiCounterBoltTest.java
+++ b/compute/src/test/java/com/chatalytics/compute/storm/bolt/EmojiCounterBoltTest.java
@@ -3,6 +3,7 @@ package com.chatalytics.compute.storm.bolt;
 import com.chatalytics.core.model.EmojiEntity;
 import com.chatalytics.core.model.FatMessage;
 import com.chatalytics.core.model.Message;
+import com.chatalytics.core.model.MessageType;
 import com.chatalytics.core.model.Room;
 import com.chatalytics.core.model.User;
 
@@ -35,7 +36,7 @@ public class EmojiCounterBoltTest {
         this.mentionTime = DateTime.now();
         this.emoji = "emoji";
 
-        this.user = new User("randomUserId", "email", false, false, null, username, null, null,
+        this.user = new User("randomUserId", "email", false, false, false, null, username, null, null,
                              null, null, null, null, null);
         this.room = new Room("randomRoomId", roomName, null, null, null, null, false, false, null,
                              null);
@@ -46,7 +47,7 @@ public class EmojiCounterBoltTest {
     public void testGetEmojisFromMessage() {
         Message message = new Message(mentionTime, "randomFrom", "randomUserId",
                                       String.format("test message with :%s:", emoji),
-                                      "randomRoomId");
+                                      "randomRoomId", MessageType.MESSAGE);
 
         FatMessage fatMessage = new FatMessage(message, user, room);
 
@@ -70,7 +71,7 @@ public class EmojiCounterBoltTest {
         Message message = new Message(mentionTime, "randomFrom", "randomUserId",
                                       String.format("test message with :%s::%s: test :%s:",
                                                     emoji, emoji, emoji),
-                                      "randomRoomId");
+                                      "randomRoomId", MessageType.MESSAGE);
 
         FatMessage fatMessage = new FatMessage(message, user, room);
 
@@ -90,7 +91,7 @@ public class EmojiCounterBoltTest {
         Message message = new Message(mentionTime, "randomFrom", "randomUserId",
                                       String.format("test http:// message :     testwith :%s::%s: "
                                           + "test :%s:", emoji, emoji, emoji),
-                                      "randomRoomId");
+                                      "randomRoomId", MessageType.MESSAGE);
 
         FatMessage fatMessage = new FatMessage(message, user, room);
 

--- a/compute/src/test/java/com/chatalytics/compute/storm/bolt/EntityExtractionBoltTest.java
+++ b/compute/src/test/java/com/chatalytics/compute/storm/bolt/EntityExtractionBoltTest.java
@@ -4,6 +4,7 @@ import com.chatalytics.compute.config.ConfigurationConstants;
 import com.chatalytics.core.model.ChatEntity;
 import com.chatalytics.core.model.FatMessage;
 import com.chatalytics.core.model.Message;
+import com.chatalytics.core.model.MessageType;
 import com.chatalytics.core.model.Room;
 import com.chatalytics.core.model.User;
 import com.google.common.collect.Maps;
@@ -57,7 +58,7 @@ public class EntityExtractionBoltTest {
         String ent2 = "Mount Everest";
         Message msg = new Message(date, mentionName, userId,
                                   String.format("Today, %s is going to climb %s", ent1, ent2),
-                                  roomId);
+                                  roomId, MessageType.MESSAGE);
         User mockUser = mock(User.class);
         when(mockUser.getMentionName()).thenReturn("jane");
         Room mockRoom = mock(Room.class);

--- a/compute/src/test/java/com/chatalytics/compute/storm/spout/SlackMessageSpoutTest.java
+++ b/compute/src/test/java/com/chatalytics/compute/storm/spout/SlackMessageSpoutTest.java
@@ -5,6 +5,7 @@ import com.chatalytics.compute.config.ConfigurationConstants;
 import com.chatalytics.compute.util.YamlUtils;
 import com.chatalytics.core.config.ChatAlyticsConfig;
 import com.chatalytics.core.model.Message;
+import com.chatalytics.core.model.MessageType;
 import com.google.common.collect.Maps;
 
 import org.apache.storm.spout.SpoutOutputCollector;
@@ -115,7 +116,7 @@ public class SlackMessageSpoutTest {
 
         // trigger with this test message
         Message triggerMessage = new Message(DateTime.now(), "Test User", "U03AFSSD", "test msg",
-                                             "C09ADF43");
+                                             "C09ADF43", MessageType.MESSAGE);
         underTest.onMessageEvent(triggerMessage, mock(Session.class));
         verify(mockSlackApiDao).getUsers();
         verify(mockSlackApiDao).getRooms();

--- a/compute/src/test/resources/slack_api_responses/channels.history.txt
+++ b/compute/src/test/resources/slack_api_responses/channels.history.txt
@@ -50,5 +50,5 @@
       "ts": "1431706792.000180"
     }
   ],
-  "has_more": true
+  "has_more": false
 }

--- a/core/src/main/java/com/chatalytics/core/json/JsonObjectMapperFactory.java
+++ b/core/src/main/java/com/chatalytics/core/json/JsonObjectMapperFactory.java
@@ -6,6 +6,7 @@ import com.chatalytics.core.model.hipchat.json.HipChatJsonModule;
 import com.chatalytics.core.model.slack.json.SlackJsonModule;
 import com.chatalytics.core.realtime.json.ChatAlyticsEventDeserializer;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.fasterxml.jackson.databind.module.SimpleModule;
@@ -53,6 +54,7 @@ public class JsonObjectMapperFactory {
 
         ObjectMapper objectMapper = new ObjectMapper();
         objectMapper.setPropertyNamingStrategy(PropertyNamingStrategy.SNAKE_CASE);
+        objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
         objectMapper.setSerializationInclusion(Include.NON_NULL);
         objectMapper.registerModule(new JodaModule());
         objectMapper.registerModule(commonModule);

--- a/core/src/main/java/com/chatalytics/core/model/Message.java
+++ b/core/src/main/java/com/chatalytics/core/model/Message.java
@@ -4,6 +4,7 @@ import com.google.common.base.MoreObjects;
 
 import org.joda.time.DateTime;
 
+import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
@@ -15,6 +16,7 @@ import java.io.Serializable;
  * @author giannis
  *
  */
+@AllArgsConstructor
 @EqualsAndHashCode
 @Getter
 public class Message implements Serializable {
@@ -24,27 +26,20 @@ public class Message implements Serializable {
     private final String fromUserId;
     private final String message;
     private final String roomId;
+    private final MessageType type;
 
     private static final long serialVersionUID = -4370348419961560257L;
-
-    public Message(DateTime date, String fromName, String fromUserId, String message,
-                   String roomId) {
-        this.date = date;
-        this.fromName = fromName;
-        this.fromUserId = fromUserId;
-        this.message = message;
-        this.roomId = roomId;
-    }
 
     @Override
     public String toString() {
         return MoreObjects.toStringHelper(this.getClass())
-            .add("date", date)
-            .add("fromName", fromName)
-            .add("fromUserId", fromUserId)
-            .add("message", message)
-            .add("roomId", roomId)
-            .toString();
+                          .add("date", date)
+                          .add("fromName", fromName)
+                          .add("fromUserId", fromUserId)
+                          .add("message", message)
+                          .add("roomId", roomId)
+                          .add("type", type)
+                          .toString();
     }
 
 }

--- a/core/src/main/java/com/chatalytics/core/model/MessageSummary.java
+++ b/core/src/main/java/com/chatalytics/core/model/MessageSummary.java
@@ -22,6 +22,7 @@ public class MessageSummary implements IMentionable<Integer> {
     private final String username;
     private final String roomName;
     private final DateTime mentionTime;
+    private final MessageType type;
 
     /**
      * Occurrences will always be 1. This field is here to make JSON serialization easier
@@ -29,10 +30,12 @@ public class MessageSummary implements IMentionable<Integer> {
     private final int occurrences;
     private final Integer value;
 
-    public MessageSummary(String username, String roomName, DateTime mentionTime) {
+    public MessageSummary(String username, String roomName, DateTime mentionTime,
+                          MessageType type) {
         this.username = username;
         this.roomName = roomName;
         this.mentionTime = mentionTime;
+        this.type = type;
         this.occurrences = 1;
         this.value = occurrences;
     }

--- a/core/src/main/java/com/chatalytics/core/model/MessageType.java
+++ b/core/src/main/java/com/chatalytics/core/model/MessageType.java
@@ -1,0 +1,78 @@
+package com.chatalytics.core.model;
+
+import com.chatalytics.core.similarity.SimilarityDimension;
+import com.google.common.base.Preconditions;
+
+import java.util.Arrays;
+
+/**
+ * All the different types of messages supported by ChatAlytics
+ *
+ * @author giannis
+ */
+public enum MessageType {
+
+    MESSAGE("message"),
+    CHANNEL_JOIN("channel_join"),
+    MESSAGE_CHANGED("message_changed"),
+    BOT_MESSAGE("bot_message"),
+    PINNED_ITEM("pinned_item"),
+    UNKNOWN("unknown");
+
+    private String type;
+
+    private MessageType(String type) {
+        this.type = type;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    @Override
+    public String toString() {
+        return type;
+    }
+
+    /**
+     * Constructs a <code>MessageType</code> from its string representation.
+     *
+     * @param value
+     *            The string type of a <code>MessageType</code>
+     * @return A <code>MessageType</code>
+     * @throws IllegalArgumentException
+     *             when the type cannot be determined or if <code>value</code> is null
+     * @throws NullPointerException if <code>type</code> is null
+     */
+    public static MessageType fromType(String type) {
+        Preconditions.checkNotNull(type, "Can't construct a message type from a null string type");
+
+        for (MessageType msgType : MessageType.values()) {
+            if (type.equals(msgType.getType())) {
+                return msgType;
+            }
+        }
+
+        String msg = String.format("Can't construct message type from %s. Supported values are %s",
+                                   type, Arrays.deepToString(SimilarityDimension.values()));
+        throw new IllegalArgumentException(msg);
+    }
+
+    /**
+     * Similar to {@link #fromType(String)} but instead of failing on identifying a type it returns
+     * {@link #UNKNOWN} instead
+     *
+     * @param type
+     *            The string type of a <code>MessageType</code>
+     * @return The identified <code>MessageType</code> or {@link #UNKNOWN} if it can't be determined
+     * @throws NullPointerException
+     *             if <code>type</code> is null
+     */
+    public static MessageType fromTypeOrUnknown(String type) {
+        try {
+            return MessageType.fromType(type);
+        } catch (IllegalArgumentException e) {
+            return UNKNOWN;
+        }
+    }
+}

--- a/core/src/main/java/com/chatalytics/core/model/User.java
+++ b/core/src/main/java/com/chatalytics/core/model/User.java
@@ -4,6 +4,7 @@ import com.google.common.base.MoreObjects;
 
 import org.joda.time.DateTime;
 
+import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
@@ -13,6 +14,7 @@ import lombok.Getter;
  * @author giannis
  *
  */
+@AllArgsConstructor
 @EqualsAndHashCode
 @Getter
 public class User {
@@ -21,6 +23,7 @@ public class User {
     private final String email;
     private final boolean deleted;
     private final boolean groupAdmin;
+    private final boolean bot;
     private final String name;
     private final String mentionName;
     private final String photoUrl;
@@ -31,24 +34,6 @@ public class User {
     private final String timezone;
     private final String title;
 
-    public User(String userId, String email, boolean deleted, boolean groupAdmin, String name,
-            String mentionName, String photoUrl, DateTime lastActiveDate, DateTime creationDate,
-            String status, String statusMessage, String timezone, String title) {
-        this.userId = userId;
-        this.email = email;
-        this.deleted = deleted;
-        this.groupAdmin = groupAdmin;
-        this.name = name;
-        this.mentionName = mentionName;
-        this.photoUrl = photoUrl;
-        this.lastActiveDate = lastActiveDate;
-        this.creationDate = creationDate;
-        this.status = status;
-        this.statusMessage = statusMessage;
-        this.timezone = timezone;
-        this.title = title;
-    }
-
     @Override
     public String toString() {
         return MoreObjects.toStringHelper(this.getClass())
@@ -56,6 +41,7 @@ public class User {
                           .add("email", email)
                           .add("deleted", deleted)
                           .add("groupAdmin", groupAdmin)
+                          .add("bot", bot)
                           .add("name", name)
                           .add("mentionName", mentionName)
                           .add("photoUrl", photoUrl)

--- a/core/src/main/java/com/chatalytics/core/model/hipchat/json/MessageDeserializer.java
+++ b/core/src/main/java/com/chatalytics/core/model/hipchat/json/MessageDeserializer.java
@@ -1,6 +1,7 @@
 package com.chatalytics.core.model.hipchat.json;
 
 import com.chatalytics.core.model.Message;
+import com.chatalytics.core.model.MessageType;
 import com.chatalytics.core.model.json.JsonChatDeserializer;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -38,7 +39,7 @@ public class MessageDeserializer extends JsonChatDeserializer<Message> {
         String userIdStr = fromStruct.get("user_id").asText();
         String message = node.get("message").asText();
 
-        return new Message(date, fromName, userIdStr, message, null);
+        return new Message(date, fromName, userIdStr, message, null, MessageType.MESSAGE);
     }
 
 }

--- a/core/src/main/java/com/chatalytics/core/model/hipchat/json/UserDeserializer.java
+++ b/core/src/main/java/com/chatalytics/core/model/hipchat/json/UserDeserializer.java
@@ -40,9 +40,9 @@ public class UserDeserializer extends JsonChatDeserializer<User> {
         String timezone = node.get("timezone").asText();
         String title = node.get("title").asText();
 
-        return new User(String.valueOf(userId), email, deleted, groupAdmin, name, mentionName,
-                        photoUrl, lastActiveDate, creationDate, status, statusMessage, timezone,
-                        title);
+        return new User(String.valueOf(userId), email, deleted, groupAdmin, false, name,
+                        mentionName, photoUrl, lastActiveDate, creationDate, status, statusMessage,
+                        timezone, title);
     }
 
 }

--- a/core/src/main/java/com/chatalytics/core/model/slack/HistoryResult.java
+++ b/core/src/main/java/com/chatalytics/core/model/slack/HistoryResult.java
@@ -1,0 +1,25 @@
+package com.chatalytics.core.model.slack;
+
+import com.chatalytics.core.model.Message;
+
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+
+import java.util.List;
+
+/**
+ * Represents the result from a channels.history slack call
+ *
+ * @author giannis
+ */
+@Getter
+@EqualsAndHashCode
+@AllArgsConstructor
+public class HistoryResult {
+
+    private final List<Message> messages;
+    private final boolean has_more;
+    private final boolean ok;
+    private final String latest;
+}

--- a/core/src/main/java/com/chatalytics/core/model/slack/json/UserDeserializer.java
+++ b/core/src/main/java/com/chatalytics/core/model/slack/json/UserDeserializer.java
@@ -38,8 +38,8 @@ public class UserDeserializer extends JsonChatDeserializer<User> {
         String email = getAsTextOrNull(profileNode.get("email"));
         String photoUrl = profileNode.get("image_32").asText();
 
-        return new User(userId, email, deleted, groupAdmin, name, mentionName, photoUrl, null,
-                        null, null, statusMessage, timezone, title);
+        return new User(userId, email, deleted, groupAdmin, false, name, mentionName, photoUrl,
+                        null, null, null, statusMessage, timezone, title);
     }
 
 }

--- a/core/src/main/java/com/chatalytics/core/similarity/SimilarityDimension.java
+++ b/core/src/main/java/com/chatalytics/core/similarity/SimilarityDimension.java
@@ -1,5 +1,7 @@
 package com.chatalytics.core.similarity;
 
+import com.google.common.base.Preconditions;
+
 import java.util.Arrays;
 
 /**
@@ -8,7 +10,10 @@ import java.util.Arrays;
  * @author giannis
  */
 public enum SimilarityDimension {
-    USER("user"), ROOM("room"), ENTITY("entity");
+
+    USER("user"),
+    ROOM("room"),
+    ENTITY("entity");
 
     private String dimensionName;
 
@@ -31,19 +36,24 @@ public enum SimilarityDimension {
      * @param dimensionName
      *            The string representation of a {@link SimilarityDimension}
      * @return A {@link SimilarityDimension}
+     * @throws IllegalArgumentException
+     *             if <code>dimensionName</code> a <code>SimilarityDimension</code> can't be
+     *             determined
+     * @throws NullPointerException if <code>dimensionName</code> is null
      */
     public static SimilarityDimension fromDimensionName(String dimensionName) {
-        if (USER.getDimensionName().equals(dimensionName)) {
-            return USER;
-        } else if (ENTITY.getDimensionName().equals(dimensionName)) {
-            return ENTITY;
-        } else if (ROOM.getDimensionName().equals(dimensionName)) {
-            return ROOM;
-        } else {
-            String msg = String.format("Can't construct similarity dimension from %s. "
-                                       + "Supported values are %s", dimensionName,
-                                       Arrays.deepToString(SimilarityDimension.values()));
-            throw new IllegalArgumentException(msg);
+        Preconditions.checkNotNull(dimensionName,
+                                   "Can't construct a similarity dimension from a null value");
+
+        for (SimilarityDimension simDim : SimilarityDimension.values()) {
+            if (dimensionName.equals(simDim.getDimensionName())) {
+                return simDim;
+            }
         }
+
+        String msg = String.format("Can't construct similarity dimension from %s. "
+                                   + "Supported values are %s", dimensionName,
+                                   Arrays.deepToString(SimilarityDimension.values()));
+        throw new IllegalArgumentException(msg);
     }
 }

--- a/core/src/test/java/com/chatalytics/core/model/MessageTypeTest.java
+++ b/core/src/test/java/com/chatalytics/core/model/MessageTypeTest.java
@@ -1,0 +1,73 @@
+package com.chatalytics.core.model;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Tests {@link MessageType}
+ *
+ * @author giannis
+ *
+ */
+public class MessageTypeTest {
+
+    @Test
+    public void testFromType() {
+
+        String type = "message";
+        MessageType msgType = MessageType.fromType(type);
+        assertEquals(MessageType.MESSAGE, msgType);
+        assertEquals(type, msgType.getType());
+        assertEquals(type, msgType.toString());
+
+        type = "channel_join";
+        msgType = MessageType.fromType(type);
+        assertEquals(MessageType.CHANNEL_JOIN, msgType);
+        assertEquals(type, msgType.getType());
+        assertEquals(type, msgType.toString());
+
+        type = "message_changed";
+        msgType = MessageType.fromType(type);
+        assertEquals(MessageType.MESSAGE_CHANGED, msgType);
+        assertEquals(type, msgType.getType());
+        assertEquals(type, msgType.toString());
+
+        type = "bot_message";
+        msgType = MessageType.fromType(type);
+        assertEquals(MessageType.BOT_MESSAGE, msgType);
+        assertEquals(type, msgType.getType());
+        assertEquals(type, msgType.toString());
+
+        type = "pinned_item";
+        msgType = MessageType.fromType(type);
+        assertEquals(MessageType.PINNED_ITEM, msgType);
+        assertEquals(type, msgType.getType());
+        assertEquals(type, msgType.toString());
+
+        type = "unknown";
+        msgType = MessageType.fromType(type);
+        assertEquals(MessageType.UNKNOWN, msgType);
+        assertEquals(type, msgType.getType());
+        assertEquals(type, msgType.toString());
+    }
+
+    @Test
+    public void testFromTypeOrUnknown() {
+        MessageType msgType = MessageType.fromTypeOrUnknown("bad name");
+        assertEquals(MessageType.UNKNOWN, msgType);
+
+        msgType = MessageType.fromTypeOrUnknown("message");
+        assertEquals(MessageType.MESSAGE, msgType);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testFromType_withBadName() {
+        MessageType.fromType("bad name");
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testFromType_withNullArg() {
+        MessageType.fromType(null);
+    }
+}

--- a/core/src/test/java/com/chatalytics/core/model/slack/json/MessageDeserializerTest.java
+++ b/core/src/test/java/com/chatalytics/core/model/slack/json/MessageDeserializerTest.java
@@ -44,7 +44,7 @@ public class MessageDeserializerTest {
     @Test
     public void testDeserialize_WithBotMessage() throws Exception {
         Message msg = objMapper.readValue(messageBotJsonStr, Message.class);
-        assertEquals("bot", msg.getFromUserId());
+        assertEquals("B0N8R69KR", msg.getFromUserId());
         assertEquals("a bot message", msg.getMessage());
         // the deserializer drops the nanoseconds
         assertEquals(new DateTime(1431719027010L), msg.getDate());

--- a/core/src/test/java/com/chatalytics/core/similarity/SimilarityDimensionTest.java
+++ b/core/src/test/java/com/chatalytics/core/similarity/SimilarityDimensionTest.java
@@ -13,17 +13,23 @@ public class SimilarityDimensionTest {
 
     @Test
     public void testFromDimensionName() {
-        SimilarityDimension simDim = SimilarityDimension.fromDimensionName("user");
+        String dimName = "user";
+        SimilarityDimension simDim = SimilarityDimension.fromDimensionName(dimName);
         assertEquals(SimilarityDimension.USER, simDim);
-        assertEquals("user", simDim.getDimensionName());
+        assertEquals(dimName, simDim.getDimensionName());
+        assertEquals(dimName, simDim.toString());
 
-        simDim = SimilarityDimension.fromDimensionName("entity");
+        dimName = "entity";
+        simDim = SimilarityDimension.fromDimensionName(dimName);
         assertEquals(SimilarityDimension.ENTITY, simDim);
-        assertEquals("entity", simDim.getDimensionName());
+        assertEquals(dimName, simDim.getDimensionName());
+        assertEquals(dimName, simDim.toString());
 
-        simDim = SimilarityDimension.fromDimensionName("room");
+        dimName = "room";
+        simDim = SimilarityDimension.fromDimensionName(dimName);
         assertEquals(SimilarityDimension.ROOM, simDim);
-        assertEquals("room", simDim.getDimensionName());
+        assertEquals(dimName, simDim.getDimensionName());
+        assertEquals(dimName, simDim.toString());
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -31,4 +37,8 @@ public class SimilarityDimensionTest {
         SimilarityDimension.fromDimensionName("bad name");
     }
 
+    @Test(expected = NullPointerException.class)
+    public void testFromDimensionName_withNullArg() {
+        SimilarityDimension.fromDimensionName(null);
+    }
 }


### PR DESCRIPTION
- Fixed bugs in mentionable dao. There's now an entity manager for every call. This avoids problems when an entitymanager throws a persistence exception and enters an unrecoverable bad state
- Created an is bot field in User so that a User object can be created for bot messages
- Added message types for various types like channel joins, bot messages edits, pinned items, etc
- Created paging in the backfilling spout. Instead of requesting data once, if there's more data we'll hit the slack API multiple times
- Making logs in the backfilling spout a little less noisy
