### PR TITLE
Adding getTopColumnByToTV

### DIFF
--- a/compute/src/main/java/com/chatalytics/compute/db/dao/EntityDAOImpl.java
+++ b/compute/src/main/java/com/chatalytics/compute/db/dao/EntityDAOImpl.java
@@ -120,4 +120,14 @@ public class EntityDAOImpl extends AbstractIdleService implements IEntityDAO {
         occurrenceStatsDAO.close();
     }
 
+    @Override
+    public Map<String, Double> getTopUsersByEoTV(Interval interval, int resultSize) {
+        return occurrenceStatsDAO.getTopColumnsByToTV("username", interval, resultSize);
+    }
+
+    @Override
+    public Map<String, Double> getTopRoomsByEoTV(Interval interval, int resultSize) {
+        return occurrenceStatsDAO.getTopColumnsByToTV("roomName", interval, resultSize);
+    }
+
 }

--- a/compute/src/main/java/com/chatalytics/compute/db/dao/IEntityDAO.java
+++ b/compute/src/main/java/com/chatalytics/compute/db/dao/IEntityDAO.java
@@ -118,4 +118,30 @@ public interface IEntityDAO extends Service {
       * @return A labeled matrix
       */
      LabeledDenseMatrix<String> getRoomSimilaritiesByEntity(Interval interval);
+
+     /**
+      * Returns a sorted map of user to a ratio, where the ratio is the entity volume over the total
+      * volume of all entities in a time range. We call this metric EoTV (entity over total volume)
+      *
+      * @param interval
+      *            The interval to get the top values in. Note that the start is inclusive and the
+      *            end is exclusive
+      * @param resultSize
+      *            The result size
+      * @return A sorted map of top users to ratio
+      */
+     Map<String, Double> getTopUsersByEoTV(Interval interval, int resultSize);
+
+     /**
+      * Returns a sorted map of rooms to a ratio, where the ratio is the entity volume over the
+      * total entity volume. We call this metric EoTV (entity over total volume)
+      *
+      * @param interval
+      *            The interval to get the top values in. Note that the start is inclusive and the
+      *            end is exclusive
+      * @param resultSize
+      *            The result size
+      * @return A sorted map of top room to ratio
+      */
+     Map<String, Double> getTopRoomsByEoTV(Interval interval, int resultSize);
 }

--- a/compute/src/main/java/com/chatalytics/compute/db/dao/IMentionableDAO.java
+++ b/compute/src/main/java/com/chatalytics/compute/db/dao/IMentionableDAO.java
@@ -143,6 +143,21 @@ public interface IMentionableDAO<K extends Serializable, T extends IMentionable<
                                     int resultSize);
 
     /**
+     * Returns a sorted map of type to a ratio, where the ratio is the type volume over the total
+     * volume. We call this metric ToTV (type over total volume)
+     *
+     * @param columnName
+     *            The column to get the top values for. eg Room or User
+     * @param interval
+     *            The interval to get the top values in. Note that the start is inclusive and the
+     *            end is exclusive
+     * @param resultSize
+     *            The result size
+     * @return A sorted map of top column to ratio
+     */
+    Map<String, Double> getTopColumnsByToTV(String columnName, Interval interval, int resultSize);
+
+    /**
      * Given a time interval this method will return a labeled room by room matrix with all the
      * similar rooms clustered together. For more information see
      * {@link GraphPartition#getSimilarityMatrix(LabeledMTJMatrix)}

--- a/compute/src/test/java/com/chatalytics/compute/db/dao/EntityDAOImplTest.java
+++ b/compute/src/test/java/com/chatalytics/compute/db/dao/EntityDAOImplTest.java
@@ -135,6 +135,26 @@ public class EntityDAOImplTest {
         assertEquals(2, result.getMatrix().length);
     }
 
+    @Test
+    public void testGetTopRoomsByToTV() {
+        Interval interval = new Interval(mentionDate.minusMillis(1), mentionDate.plusMillis(1));
+
+        Map<String, Double> result = underTest.getTopRoomsByEoTV(interval, 10);
+        assertEquals(2, result.size());
+        assertEquals(0.75, result.get("room1"), 0);
+        assertEquals(0.25, result.get("room2"), 0);
+    }
+
+    @Test
+    public void testGetTopUsersByToTV() {
+        Interval interval = new Interval(mentionDate.minusMillis(1), mentionDate.plusMillis(1));
+
+        Map<String, Double> result = underTest.getTopUsersByEoTV(interval, 10);
+        assertEquals(2, result.size());
+        assertEquals(0.75, result.get("giannis"), 0);
+        assertEquals(0.25, result.get("jane"), 0);
+    }
+
     @After
     public void tearDown() throws Exception {
         underTest.stopAsync().awaitTerminated();


### PR DESCRIPTION
- Adding a method that can get the top column (room or username, etc) by type over its total volume in a timerange
- Exposing topRoomsByEoTV and topUsersByEoTV in the entity dao and adding tests for it
- Fixing a bug in the mentionable DAO where the time range was all inclusive instead of just the start date
