### PR TITLE
Set roomName to null instead of empty string

### DIFF
--- a/compute/src/main/java/com/chatalytics/compute/storm/bolt/EmojiCounterBolt.java
+++ b/compute/src/main/java/com/chatalytics/compute/storm/bolt/EmojiCounterBolt.java
@@ -67,10 +67,8 @@ public class EmojiCounterBolt extends ChatAlyticsBaseBolt {
         OfInt charIterator = message.chars().iterator();
 
         Room room = fatMessage.getRoom();
-        String roomName;
-        if (room == null) {
-            roomName = "";
-        } else {
+        String roomName = null;
+        if (room != null) {
             roomName = room.getName();
         }
 
@@ -129,7 +127,9 @@ public class EmojiCounterBolt extends ChatAlyticsBaseBolt {
     @Override
     public void cleanup() {
         LOG.debug("Cleaning up {}", this.getClass().getSimpleName());
-        emojiDao.stopAsync().awaitTerminated();
+        if (emojiDao != null && emojiDao.isRunning()) {
+            emojiDao.stopAsync().awaitTerminated();
+        }
     }
 
 }

--- a/compute/src/main/java/com/chatalytics/compute/storm/bolt/EntityExtractionBolt.java
+++ b/compute/src/main/java/com/chatalytics/compute/storm/bolt/EntityExtractionBolt.java
@@ -124,10 +124,8 @@ public class EntityExtractionBolt extends ChatAlyticsBaseBolt {
                 occurrences = existingEntity.getOccurrences() + 1;
             }
             Room room = fatMessage.getRoom();
-            String roomName;
-            if (room == null) {
-                roomName = "";
-            } else {
+            String roomName = null;
+            if (room != null) {
                 roomName = room.getName();
             }
             entities.put(entity, new ChatEntity(entity,
@@ -151,7 +149,9 @@ public class EntityExtractionBolt extends ChatAlyticsBaseBolt {
     @Override
     public void cleanup() {
         LOG.debug("Cleaning up {}", this.getClass().getSimpleName());
-        entityDao.stopAsync().awaitTerminated();
+        if (entityDao != null && entityDao.isRunning()) {
+            entityDao.stopAsync().awaitTerminated();
+        }
     }
 
 }

--- a/compute/src/test/java/com/chatalytics/compute/storm/bolt/EmojiCounterBoltTest.java
+++ b/compute/src/test/java/com/chatalytics/compute/storm/bolt/EmojiCounterBoltTest.java
@@ -1,19 +1,41 @@
 package com.chatalytics.compute.storm.bolt;
 
+import com.chatalytics.compute.config.ConfigurationConstants;
+import com.chatalytics.core.config.ChatAlyticsConfig;
 import com.chatalytics.core.model.EmojiEntity;
 import com.chatalytics.core.model.FatMessage;
 import com.chatalytics.core.model.Message;
 import com.chatalytics.core.model.MessageType;
 import com.chatalytics.core.model.Room;
 import com.chatalytics.core.model.User;
+import com.chatalytics.core.util.YamlUtils;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
 
+import org.apache.storm.task.OutputCollector;
+import org.apache.storm.task.TopologyContext;
+import org.apache.storm.topology.OutputFieldsDeclarer;
+import org.apache.storm.tuple.Fields;
+import org.apache.storm.tuple.Tuple;
+import org.apache.storm.tuple.TupleImpl;
+import org.apache.storm.tuple.Values;
 import org.joda.time.DateTime;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
 import java.util.List;
+import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.when;
 
 /**
  * Tests {@link EmojiCounterBolt}
@@ -22,7 +44,7 @@ import static org.junit.Assert.assertEquals;
  */
 public class EmojiCounterBoltTest {
 
-    private EmojiCounterBolt undertest;
+    private EmojiCounterBolt underTest;
     private User user;
     private Room room;
     private DateTime mentionTime;
@@ -30,17 +52,39 @@ public class EmojiCounterBoltTest {
 
     @Before
     public void setUp() {
-        undertest = new EmojiCounterBolt();
-        String username = "randomUserName";
-        String roomName = "randomRoomName";
-        this.mentionTime = DateTime.now();
-        this.emoji = "emoji";
+        underTest = new EmojiCounterBolt();
+        mentionTime = DateTime.now();
+        emoji = "emoji";
+        user = new User("randomUserId", "email", false, false, false, null, "randomUserName", null,
+                        null, null, null, null, null, null);
+        room = new Room("randomRoomId", "randomRoomName", null, null, null, null, false, false,
+                        null, null);
+    }
 
-        this.user = new User("randomUserId", "email", false, false, false, null, username, null, null,
-                             null, null, null, null, null);
-        this.room = new Room("randomRoomId", roomName, null, null, null, null, false, false, null,
-                             null);
+    @Test
+    public void testExecute() {
+        Message message = new Message(mentionTime, "randomFrom", "randomUserId",
+                                      String.format("test message with :%s:", emoji),
+                                      "randomRoomId", MessageType.MESSAGE);
+        FatMessage fatMessage = new FatMessage(message, user, room);
+        List<Object> values = Lists.newArrayList(fatMessage);
 
+        TopologyContext context = mock(TopologyContext.class);
+        Fields fields = mock(Fields.class);
+        when(fields.size()).thenReturn(1);
+        when(context.getComponentOutputFields(anyString(), anyString())).thenReturn(fields);
+        Tuple input = new TupleImpl(context, values, 0, "stream-id");
+        OutputCollector collector = mock(OutputCollector.class);
+
+        ChatAlyticsConfig config = new ChatAlyticsConfig();
+        config.computeConfig.apiRetries = 0;
+        config.persistenceUnitName = "chatalytics-db-test";
+        Map<Object, Object> stormConf = Maps.newHashMapWithExpectedSize(1);
+        stormConf.put(ConfigurationConstants.CHATALYTICS_CONFIG.txt, YamlUtils.writeYaml(config));
+
+        underTest.prepare(stormConf, context, collector);
+        underTest.execute(input);
+        verify(collector).emit(any(Values.class));
     }
 
     @Test
@@ -51,7 +95,7 @@ public class EmojiCounterBoltTest {
 
         FatMessage fatMessage = new FatMessage(message, user, room);
 
-        List<EmojiEntity> emojis = undertest.getEmojisFromMessage(fatMessage);
+        List<EmojiEntity> emojis = underTest.getEmojisFromMessage(fatMessage);
 
         assertEquals(1, emojis.size());
         EmojiEntity firstEmoji = emojis.get(0);
@@ -60,6 +104,34 @@ public class EmojiCounterBoltTest {
         assertEquals(mentionTime, firstEmoji.getMentionTime());
         assertEquals(emoji, firstEmoji.getValue());
         assertEquals(1, firstEmoji.getOccurrences());
+    }
+
+    @Test
+    public void testGetEmojisFromMessage_noRoom() {
+        Message message = new Message(mentionTime, "randomFrom", "randomUserId",
+                                      String.format("test message with :%s:", emoji),
+                                      "randomRoomId", MessageType.MESSAGE);
+
+        FatMessage fatMessage = new FatMessage(message, user, null);
+
+        List<EmojiEntity> emojis = underTest.getEmojisFromMessage(fatMessage);
+
+        assertEquals(1, emojis.size());
+        EmojiEntity firstEmoji = emojis.get(0);
+        assertEquals(user.getMentionName(), firstEmoji.getUsername());
+        assertNull(firstEmoji.getRoomName());
+        assertEquals(mentionTime, firstEmoji.getMentionTime());
+        assertEquals(emoji, firstEmoji.getValue());
+        assertEquals(1, firstEmoji.getOccurrences());
+    }
+
+    @Test
+    public void testGetEmojisFromMessage_nullMessage() {
+        Message message = new Message(mentionTime, "randomFrom", "randomUserId", null,
+                                      "randomRoomId", MessageType.MESSAGE);
+        FatMessage fatMessage = new FatMessage(message, user, room);
+        List<EmojiEntity> emojis = underTest.getEmojisFromMessage(fatMessage);
+        assertTrue(emojis.isEmpty());
     }
 
     /**
@@ -75,7 +147,7 @@ public class EmojiCounterBoltTest {
 
         FatMessage fatMessage = new FatMessage(message, user, room);
 
-        List<EmojiEntity> emojis = undertest.getEmojisFromMessage(fatMessage);
+        List<EmojiEntity> emojis = underTest.getEmojisFromMessage(fatMessage);
 
         assertEquals(1, emojis.size());
         EmojiEntity firstEmoji = emojis.get(0);
@@ -95,7 +167,7 @@ public class EmojiCounterBoltTest {
 
         FatMessage fatMessage = new FatMessage(message, user, room);
 
-        List<EmojiEntity> emojis = undertest.getEmojisFromMessage(fatMessage);
+        List<EmojiEntity> emojis = underTest.getEmojisFromMessage(fatMessage);
 
         assertEquals(1, emojis.size());
         EmojiEntity firstEmoji = emojis.get(0);
@@ -104,6 +176,34 @@ public class EmojiCounterBoltTest {
         assertEquals(mentionTime, firstEmoji.getMentionTime());
         assertEquals(emoji, firstEmoji.getValue());
         assertEquals(3, firstEmoji.getOccurrences());
+    }
+
+    @Test
+    public void testDeclareOutputFields() {
+        OutputFieldsDeclarer fields = mock(OutputFieldsDeclarer.class);
+        underTest.declareOutputFields(fields);
+        verify(fields).declare(any(Fields.class));
+    }
+
+    @Test
+    public void testPrepare() {
+        ChatAlyticsConfig config = new ChatAlyticsConfig();
+        config.computeConfig.apiRetries = 0;
+        config.persistenceUnitName = "chatalytics-db-test";
+        Map<Object, Object> stormConf = Maps.newHashMapWithExpectedSize(1);
+        stormConf.put(ConfigurationConstants.CHATALYTICS_CONFIG.txt, YamlUtils.writeYaml(config));
+
+        TopologyContext context = mock(TopologyContext.class);
+        OutputCollector collector = mock(OutputCollector.class);
+
+        underTest.prepare(stormConf, context, collector);
+        verifyZeroInteractions(context);
+        verifyZeroInteractions(collector);
+    }
+
+    @After
+    public void tearDown() {
+        underTest.cleanup();
     }
 
 }

--- a/compute/src/test/java/com/chatalytics/compute/storm/bolt/EntityExtractionBoltTest.java
+++ b/compute/src/test/java/com/chatalytics/compute/storm/bolt/EntityExtractionBoltTest.java
@@ -1,16 +1,23 @@
 package com.chatalytics.compute.storm.bolt;
 
 import com.chatalytics.compute.config.ConfigurationConstants;
+import com.chatalytics.core.config.ChatAlyticsConfig;
 import com.chatalytics.core.model.ChatEntity;
 import com.chatalytics.core.model.FatMessage;
 import com.chatalytics.core.model.Message;
 import com.chatalytics.core.model.MessageType;
 import com.chatalytics.core.model.Room;
 import com.chatalytics.core.model.User;
+import com.chatalytics.core.util.YamlUtils;
+import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 
 import org.apache.storm.task.OutputCollector;
 import org.apache.storm.task.TopologyContext;
+import org.apache.storm.tuple.Fields;
+import org.apache.storm.tuple.Tuple;
+import org.apache.storm.tuple.TupleImpl;
+import org.apache.storm.tuple.Values;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.junit.After;
@@ -21,7 +28,13 @@ import java.util.List;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 /**
@@ -33,16 +46,50 @@ import static org.mockito.Mockito.when;
 public class EntityExtractionBoltTest {
 
     private EntityExtractionBolt underTest;
+    private User user;
+    private Room room;
+    private TopologyContext context;
+    private OutputCollector collector;
 
     @Before
     public void setUp() throws Exception {
         underTest = new EntityExtractionBolt();
-        Map<String, String> confMap = Maps.newHashMapWithExpectedSize(1);
-        confMap.put(ConfigurationConstants.CHATALYTICS_CONFIG.txt,
-                    "computeConfig:\n" +
-                    "    apiRetries: 0\n" +
-                    "persistenceUnitName: 'chatalytics-db-test'");
-        underTest.prepare(confMap, mock(TopologyContext.class), mock(OutputCollector.class));
+
+
+        ChatAlyticsConfig config = new ChatAlyticsConfig();
+        config.computeConfig.apiRetries = 0;
+        config.persistenceUnitName = "chatalytics-db-test";
+        Map<Object, Object> stormConf = Maps.newHashMapWithExpectedSize(1);
+        stormConf.put(ConfigurationConstants.CHATALYTICS_CONFIG.txt, YamlUtils.writeYaml(config));
+
+        collector = mock(OutputCollector.class);
+        context = mock(TopologyContext.class);
+        underTest.prepare(stormConf, context, collector);
+
+        Fields fields = mock(Fields.class);
+        when(fields.size()).thenReturn(1);
+        when(context.getComponentOutputFields(anyString(), anyString())).thenReturn(fields);
+
+        user = new User("randomUserId", "email", false, false, false, null, "randomUserName", null,
+                        null, null, null, null, null, null);
+        room = new Room("randomRoomId", "randomRoomName", null, null, null, null, false, false,
+                        null, null);
+    }
+
+    @Test
+    public void testExecute() {
+        String ent1 = "Jane Doe";
+        String ent2 = "Mount Everest";
+        Message msg = new Message(DateTime.now(), "jane", "u1",
+                                  String.format("Today, %s is going to climb %s", ent1, ent2),
+                                  "r1", MessageType.MESSAGE);
+        FatMessage fatMessage = new FatMessage(msg, user, room);
+        List<Object> values = Lists.newArrayList(fatMessage);
+        Tuple input = new TupleImpl(context, values, 0, "stream-id");
+
+        underTest.execute(input);
+
+        verify(collector, times(2)).emit(any(Values.class));
     }
 
     /**
@@ -59,11 +106,7 @@ public class EntityExtractionBoltTest {
         Message msg = new Message(date, mentionName, userId,
                                   String.format("Today, %s is going to climb %s", ent1, ent2),
                                   roomId, MessageType.MESSAGE);
-        User mockUser = mock(User.class);
-        when(mockUser.getMentionName()).thenReturn("jane");
-        Room mockRoom = mock(Room.class);
-        when(mockRoom.getName()).thenReturn("theroom");
-        FatMessage fatMessage = new FatMessage(msg, mockUser, mockRoom);
+        FatMessage fatMessage = new FatMessage(msg, user, room);
         List<ChatEntity> entities = underTest.extractEntities(fatMessage);
         Map<String, ChatEntity> entitiesMap = Maps.newHashMapWithExpectedSize(entities.size());
         entities.forEach((entity) -> entitiesMap.put(entity.getValue(), entity));
@@ -78,6 +121,49 @@ public class EntityExtractionBoltTest {
         assertEquals(ent2, entity.getValue());
         assertEquals(1, entity.getOccurrences());
         assertEquals(date, entity.getMentionTime());
+    }
+
+    @Test
+    public void testExtractEntities_nullMessage() {
+        DateTime date = DateTime.now().withZone(DateTimeZone.UTC);
+        Message msg = new Message(date, "jane", "1", null, "100", MessageType.MESSAGE);
+        User mockUser = mock(User.class);
+        when(mockUser.getMentionName()).thenReturn("jane");
+        Room mockRoom = mock(Room.class);
+        when(mockRoom.getName()).thenReturn("theroom");
+        FatMessage fatMessage = new FatMessage(msg, mockUser, mockRoom);
+        List<ChatEntity> result = underTest.extractEntities(fatMessage);
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    public void testExtractEntities_doubleOccurrence() {
+        String mentionName = "jane";
+        String userId = "1";
+        String roomId = "100";
+        String ent = "Mount Everest";
+        Message msg = new Message(DateTime.now(), mentionName, userId,
+                                  String.format("Today, I'm going to climb %s and %s", ent, ent),
+                                  roomId, MessageType.MESSAGE);
+        FatMessage fatMessage = new FatMessage(msg, user, room);
+        List<ChatEntity> entities = underTest.extractEntities(fatMessage);
+        assertEquals(1, entities.size());
+        assertEquals(2, entities.get(0).getOccurrences());
+    }
+
+    @Test
+    public void testExtractEntities_nullRoom() {
+        String mentionName = "jane";
+        String userId = "1";
+        String roomId = "100";
+        String ent = "Mount Everest";
+        Message msg = new Message(DateTime.now(), mentionName, userId,
+                                  String.format("Today, I'm going to climb %s", ent),
+                                  roomId, MessageType.MESSAGE);
+        FatMessage fatMessage = new FatMessage(msg, user, null);
+        List<ChatEntity> entities = underTest.extractEntities(fatMessage);
+        assertEquals(1, entities.size());
+        assertNull(entities.get(0).getRoomName());
     }
 
     @After


### PR DESCRIPTION
- Set room name to null instead of empty string whenever it's not available
- Increase test coverage in the entity extraction bolt and the emoji counter bolt
