### PR TITLE
Try and create a room with room ID

### DIFF
--- a/compute/src/main/java/com/chatalytics/compute/storm/spout/SlackMessageSpout.java
+++ b/compute/src/main/java/com/chatalytics/compute/storm/spout/SlackMessageSpout.java
@@ -22,6 +22,7 @@ import org.apache.storm.tuple.Fields;
 import org.apache.storm.tuple.Values;
 import org.glassfish.tyrus.container.jdk.client.JdkContainerProvider;
 import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -150,7 +151,10 @@ public class SlackMessageSpout extends BaseRichSpout {
         }
 
         Room room = rooms.get(message.getRoomId());
-
+        if (room == null && message.getRoomId() != null) {
+            room = new Room(message.getRoomId(), message.getRoomId(), null,
+                            DateTime.now(DateTimeZone.UTC), null, null, false, true, null, null);
+        }
         FatMessage fatMessage = new FatMessage(message, fromUser, room);
         unemittedMessages.add(fatMessage);
     }

--- a/compute/src/main/resources/chatalytics-slack.yaml
+++ b/compute/src/main/resources/chatalytics-slack.yaml
@@ -6,7 +6,7 @@ computeConfig:
     filesToRead:
         'com.chatalytics.bolts.sentiment.words': files/sentiment_words.csv
     chatConfig: !!com.chatalytics.core.config.SlackConfig
-        baseSlackURL: https://slack.com/api/
+        baseAPIURL: https://slack.com/api/
         authTokens: ['0']
 webConfig:
     port: 8080

--- a/core/src/main/java/com/chatalytics/core/model/slack/json/MessageDeserializer.java
+++ b/core/src/main/java/com/chatalytics/core/model/slack/json/MessageDeserializer.java
@@ -45,7 +45,8 @@ public class MessageDeserializer extends JsonChatDeserializer<Message> {
 
             JsonNode attachmentNode = node.get("attachments");
             if (attachmentNode != null) {
-                node = attachmentNode;
+                // just get the first one
+                node = attachmentNode.iterator().next();
             }
         }
 
@@ -63,14 +64,9 @@ public class MessageDeserializer extends JsonChatDeserializer<Message> {
 
         String message = getAsTextOrNull(node.get("text"));
 
-        try {
-            if (message == null) {
-                message = getAsTextOrNull(node.get("pretext"));
-            }
-        } catch (Exception e) {
-            throw new RuntimeException(node.toString(), e);
+        if (message == null) {
+            message = getAsTextOrNull(node.get("pretext"));
         }
-
         return new Message(date, fromName, fromUserId, message, channelId, messageType);
     }
 

--- a/core/src/test/java/com/chatalytics/core/model/slack/json/MessageDeserializerTest.java
+++ b/core/src/test/java/com/chatalytics/core/model/slack/json/MessageDeserializerTest.java
@@ -1,6 +1,7 @@
 package com.chatalytics.core.model.slack.json;
 
 import com.chatalytics.core.model.data.Message;
+import com.chatalytics.core.model.data.MessageType;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import org.joda.time.DateTime;
@@ -36,6 +37,7 @@ public class MessageDeserializerTest {
         // the deserializer drops the nanoseconds
         assertEquals(new DateTime(1431708451000L), msg.getDate());
         assertNull(msg.getFromName());
+        assertEquals(MessageType.MESSAGE, msg.getType());
     }
 
     /**
@@ -49,6 +51,18 @@ public class MessageDeserializerTest {
         // the deserializer drops the nanoseconds
         assertEquals(new DateTime(1431719027010L), msg.getDate());
         assertEquals("bot", msg.getFromName());
+        assertEquals(MessageType.BOT_MESSAGE, msg.getType());
+    }
+
+    @Test
+    public void testDeserialize_withAttachments() throws Exception {
+        Message msg = objMapper.readValue(jiraStr, Message.class);
+        assertEquals("B0234S4SHT", msg.getFromUserId());
+        assertEquals("Change <http://jira.net/TI-5|TI-5>", msg.getMessage());
+        // the deserializer drops the nanoseconds
+        assertEquals(new DateTime(1464723327000L), msg.getDate());
+        assertEquals(null, msg.getFromName());
+        assertEquals(MessageType.BOT_MESSAGE, msg.getType());
     }
 
     private final String messageJsonStr = "{" +
@@ -70,5 +84,26 @@ public class MessageDeserializerTest {
                                                  "\"subtype\": \"bot_message\", " +
                                                  "\"ts\": \"1431719027.010187\"" +
                                              "}";
+
+    private final String jiraStr = "{" +
+                                       "\"text\": \"\"," +
+                                       "\"bot_id\": \"B0234S4SHT\"," +
+                                       "\"attachments\": [{" +
+                                           "\"fallback\": \"Change <http://jira.net/TI-5|TI-5>\"," +
+                                           "\"pretext\": \"Change <http://jira.net/TI-5|TI-5>\"," +
+                                           "\"title\": \"Computers needed\"," +
+                                           "\"id\": 1," +
+                                           "\"title_link\": \"http://jira.net/TI-5\"," +
+                                           "\"color\": \"daa038\"," +
+                                           "\"fields\": [{" +
+                                               "\"title\": \"Priority\"," +
+                                               "\"value\": \"Minor\"," +
+                                               "\"short\": true" +
+                                           "}]" +
+                                       "}]," +
+                                       "\"type\": \"message\"," +
+                                       "\"subtype\": \"bot_message\"," +
+                                       "\"ts\": \"1464723327.000002\"" +
+                                   "}";
 
 }

--- a/web/src/test/java/com/chatalytics/web/utils/DateTimeUtilsTest.java
+++ b/web/src/test/java/com/chatalytics/web/utils/DateTimeUtilsTest.java
@@ -44,4 +44,19 @@ public class DateTimeUtilsTest {
         assertEquals(DateTimeUtils.getDateTimeFromParameter(startTime, dtz), interval.getStart());
         assertEquals(DateTimeUtils.getDateTimeFromParameter(endTime, dtz), interval.getEnd());
     }
+
+    /**
+     * Checks to see if the interval is returned correctly
+     */
+    @Test
+    public void testGetIntervalFromParameters_withHours() {
+        String startTime = "2016-01-01_09";
+        String endTime = "2016-02-02_10";
+        DateTimeZone dtz = DateTimeZone.UTC;
+
+        Interval interval = DateTimeUtils.getIntervalFromParameters(startTime, endTime, dtz);
+
+        assertEquals(DateTimeUtils.getDateTimeFromParameter(startTime, dtz), interval.getStart());
+        assertEquals(DateTimeUtils.getDateTimeFromParameter(endTime, dtz), interval.getEnd());
+    }
 }


### PR DESCRIPTION
- The slack message spout will now create a new room with the name and id of the room that of the channel ID from the message class whenever it's not null
- More tests to cover for that case and other message deserialization cases
