### PR TITLE
Make local chat DAO return empty emoji list

### DIFF
--- a/compute/src/main/java/com/chatalytics/compute/chat/dao/local/LocalChatDao.java
+++ b/compute/src/main/java/com/chatalytics/compute/chat/dao/local/LocalChatDao.java
@@ -4,12 +4,10 @@ import com.chatalytics.compute.chat.dao.IChatApiDAO;
 import com.chatalytics.core.RandomStringUtils;
 import com.chatalytics.core.config.ChatAlyticsConfig;
 import com.chatalytics.core.config.LocalTestConfig;
-import com.chatalytics.core.emoji.LocalEmojiUtils;
-import com.chatalytics.core.json.JsonObjectMapperFactory;
 import com.chatalytics.core.model.data.Message;
 import com.chatalytics.core.model.data.Room;
 import com.chatalytics.core.model.data.User;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableMap;
 
 import org.apache.storm.shade.com.google.common.collect.Maps;
 import org.joda.time.DateTime;
@@ -32,8 +30,6 @@ public class LocalChatDao implements IChatApiDAO {
 
     private final Map<String, User> users;
     private final Map<String, Room> rooms;
-    private final ObjectMapper objectMapper;
-    private final Map<String, String> emojis;
 
     public LocalChatDao(ChatAlyticsConfig config) {
         LocalTestConfig localConfig = (LocalTestConfig) config.computeConfig.chatConfig;
@@ -49,8 +45,6 @@ public class LocalChatDao implements IChatApiDAO {
 
         this.users = createRandomUsers(localConfig.numUsers, rand);
         this.rooms = createRandomRooms(localConfig.numRooms, rand);
-        this.objectMapper = JsonObjectMapperFactory.createObjectMapper(config.inputType);
-        this.emojis = LocalEmojiUtils.getUnicodeEmojis(objectMapper);
     }
 
     /**
@@ -90,7 +84,7 @@ public class LocalChatDao implements IChatApiDAO {
      */
     @Override
     public Map<String, String> getEmojis() {
-        return emojis;
+        return ImmutableMap.of();
     }
 
     /**

--- a/compute/src/test/java/com/chatalytics/compute/chat/dao/local/LocalChatDaoTest.java
+++ b/compute/src/test/java/com/chatalytics/compute/chat/dao/local/LocalChatDaoTest.java
@@ -14,6 +14,7 @@ import java.util.Map;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 
 /**
@@ -78,7 +79,7 @@ public class LocalChatDaoTest {
     public void testGetEmojis() {
         Map<String, String> result = underTest.getEmojis();
         assertNotNull(result);
-        assertFalse(result.isEmpty());
+        assertTrue(result.isEmpty());
     }
 
 }


### PR DESCRIPTION
- Actually make the local chat DAO return an empty map of emojis to be more consistent with how the other chat DAOs work
