### PR TITLE
Add user similarities by emoji and entity

### DIFF
--- a/compute/src/main/java/com/chatalytics/compute/db/dao/EmojiDAOImpl.java
+++ b/compute/src/main/java/com/chatalytics/compute/db/dao/EmojiDAOImpl.java
@@ -101,8 +101,16 @@ public class EmojiDAOImpl extends AbstractIdleService implements IEmojiDAO {
      * {@inheritDoc}
      */
     @Override
-    public LabeledDenseMatrix<String> getRoomSimilaritiesByEntity(Interval interval) {
+    public LabeledDenseMatrix<String> getRoomSimilaritiesByEmoji(Interval interval) {
         return occurrenceStatsDAO.getRoomSimilaritiesByValue(interval);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public LabeledDenseMatrix<String> getUserSimilaritiesByEmoji(Interval interval) {
+        return occurrenceStatsDAO.getUserSimilaritiesByValue(interval);
     }
 
     /**

--- a/compute/src/main/java/com/chatalytics/compute/db/dao/EntityDAOImpl.java
+++ b/compute/src/main/java/com/chatalytics/compute/db/dao/EntityDAOImpl.java
@@ -110,6 +110,14 @@ public class EntityDAOImpl extends AbstractIdleService implements IEntityDAO {
      * {@inheritDoc}
      */
     @Override
+    public LabeledDenseMatrix<String> getUserSimilaritiesByEntity(Interval interval) {
+        return occurrenceStatsDAO.getUserSimilaritiesByValue(interval);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     public Map<String, Double> getActiveUsersByMethod(Interval interval,
                                                       ActiveMethod method,
                                                       int resultSize) {
@@ -154,5 +162,4 @@ public class EntityDAOImpl extends AbstractIdleService implements IEntityDAO {
     protected void shutDown() throws Exception {
         occurrenceStatsDAO.close();
     }
-
 }

--- a/compute/src/main/java/com/chatalytics/compute/db/dao/IEmojiDAO.java
+++ b/compute/src/main/java/com/chatalytics/compute/db/dao/IEmojiDAO.java
@@ -115,7 +115,18 @@ public interface IEmojiDAO extends Service {
       *            The interval to search in
       * @return A labeled matrix
       */
-     LabeledDenseMatrix<String> getRoomSimilaritiesByEntity(Interval interval);
+     LabeledDenseMatrix<String> getRoomSimilaritiesByEmoji(Interval interval);
+
+     /**
+      * Given a time interval this method will return a labeled user by user matrix with all the
+      * similar users, based on the emoji value clustered together. For more information see
+      * {@link GraphPartition#getSimilarityMatrix(LabeledMTJMatrix)}
+      *
+      * @param interval
+      *            The interval to search in
+      * @return A labeled matrix
+      */
+     LabeledDenseMatrix<String> getUserSimilaritiesByEmoji(Interval interval);
 
      /**
       * Returns a sorted map of users to a ratio, where the ratio is one of {@link ActiveMethod}s

--- a/compute/src/main/java/com/chatalytics/compute/db/dao/IEntityDAO.java
+++ b/compute/src/main/java/com/chatalytics/compute/db/dao/IEntityDAO.java
@@ -121,6 +121,17 @@ public interface IEntityDAO extends Service {
      LabeledDenseMatrix<String> getRoomSimilaritiesByEntity(Interval interval);
 
      /**
+      * Given a time interval this method will return a labeled user by user matrix with all the
+      * similar users, based on the entity value clustered together. For more information see
+      * {@link GraphPartition#getSimilarityMatrix(LabeledMTJMatrix)}
+      *
+      * @param interval
+      *            The interval to search in
+      * @return A labeled matrix
+      */
+     LabeledDenseMatrix<String> getUserSimilaritiesByEntity(Interval interval);
+
+     /**
       * Returns a sorted map of users to a ratio, where the ratio is one of {@link ActiveMethod}s
       *
       * @param interval

--- a/compute/src/test/java/com/chatalytics/compute/db/dao/EmojiDAOImplTest.java
+++ b/compute/src/test/java/com/chatalytics/compute/db/dao/EmojiDAOImplTest.java
@@ -159,9 +159,17 @@ public class EmojiDAOImplTest {
     }
 
     @Test
-    public void testGetRoomSimilaritiesByEntity() {
+    public void testGetRoomSimilaritiesByEmoji() {
         Interval timeInterval = new Interval(mentionDate, mentionDate.plusHours(3));
-        LabeledDenseMatrix<String> result = underTest.getRoomSimilaritiesByEntity(timeInterval);
+        LabeledDenseMatrix<String> result = underTest.getRoomSimilaritiesByEmoji(timeInterval);
+        assertEquals(2, result.getLabels().size());
+        assertEquals(2, result.getMatrix().length);
+    }
+
+    @Test
+    public void testGetUserSimilaritiesByEmoji() {
+        Interval timeInterval = new Interval(mentionDate, mentionDate.plusHours(3));
+        LabeledDenseMatrix<String> result = underTest.getUserSimilaritiesByEmoji(timeInterval);
         assertEquals(2, result.getLabels().size());
         assertEquals(2, result.getMatrix().length);
     }

--- a/compute/src/test/java/com/chatalytics/compute/db/dao/EntityDAOImplTest.java
+++ b/compute/src/test/java/com/chatalytics/compute/db/dao/EntityDAOImplTest.java
@@ -168,6 +168,14 @@ public class EntityDAOImplTest {
     }
 
     @Test
+    public void testGetUserSimilaritiesByEntity() {
+        Interval timeInterval = new Interval(mentionDate, mentionDate.plusHours(3));
+        LabeledDenseMatrix<String> result = underTest.getUserSimilaritiesByEntity(timeInterval);
+        assertEquals(2, result.getLabels().size());
+        assertEquals(2, result.getMatrix().length);
+    }
+
+    @Test
     public void testGetTopRoomsByMethod() {
         Interval interval = new Interval(mentionDate.minusMillis(1), mentionDate.plusMillis(1));
 

--- a/web/src/main/java/com/chatalytics/web/resources/EmojisResource.java
+++ b/web/src/main/java/com/chatalytics/web/resources/EmojisResource.java
@@ -131,7 +131,9 @@ public class EmojisResource {
         Interval interval = DateTimeUtils.getIntervalFromParameters(startTimeStr, endTimeStr, dtz);
 
         if (firstDim == DimensionType.ROOM && secondDim == DimensionType.EMOJI) {
-            return emojiDao.getRoomSimilaritiesByEntity(interval);
+            return emojiDao.getRoomSimilaritiesByEmoji(interval);
+        } else if (firstDim == DimensionType.USER && secondDim == DimensionType.EMOJI) {
+            return emojiDao.getUserSimilaritiesByEmoji(interval);
         } else {
             String formatStr = "The dimension combination you specified (%s, %s) is not supported";
             throw new UnsupportedOperationException(String.format(formatStr, firstDimStr,

--- a/web/src/main/java/com/chatalytics/web/resources/EntitiesResource.java
+++ b/web/src/main/java/com/chatalytics/web/resources/EntitiesResource.java
@@ -116,6 +116,8 @@ public class EntitiesResource {
 
         if (firstDim == DimensionType.ROOM && secondDim == DimensionType.ENTITY) {
             return entityDao.getRoomSimilaritiesByEntity(interval);
+        } else if (firstDim == DimensionType.USER && secondDim == DimensionType.ENTITY) {
+            return entityDao.getUserSimilaritiesByEntity(interval);
         } else {
             String formatStr = "The dimension combination you specified (%s, %s) is not supported";
             throw new UnsupportedOperationException(String.format(formatStr, firstDimStr,

--- a/web/src/test/java/com/chatalytics/web/resources/EmojisResourceTest.java
+++ b/web/src/test/java/com/chatalytics/web/resources/EmojisResourceTest.java
@@ -136,13 +136,29 @@ public class EmojisResourceTest {
      * Tests the similarities endpoint
      */
     @Test
-    public void testGetSimilarities_RoomByEntity() throws Exception {
+    public void testGetSimilarities_RoomByEmoji() throws Exception {
         DateTimeFormatter dtf = DateTimeUtils.PARAMETER_WITH_DAY_DTF.withZone(dtZone);
         String startTimeStr = dtf.print(mentionTime.minusDays(1));
         String endTimeStr = dtf.print(mentionTime.plusDays(1));
 
         LabeledDenseMatrix<String> ldm = underTest.getSimilarities(
                 startTimeStr, endTimeStr, DimensionType.ROOM.getDimensionName(),
+                DimensionType.EMOJI.getDimensionName());
+        assertEquals(4, ldm.getLabels().size());
+        assertEquals(4, ldm.getMatrix().length);
+    }
+
+    /**
+     * Tests the similarities endpoint
+     */
+    @Test
+    public void testGetSimilarities_UserByEmoji() throws Exception {
+        DateTimeFormatter dtf = DateTimeUtils.PARAMETER_WITH_DAY_DTF.withZone(dtZone);
+        String startTimeStr = dtf.print(mentionTime.minusDays(1));
+        String endTimeStr = dtf.print(mentionTime.plusDays(1));
+
+        LabeledDenseMatrix<String> ldm = underTest.getSimilarities(
+                startTimeStr, endTimeStr, DimensionType.USER.getDimensionName(),
                 DimensionType.EMOJI.getDimensionName());
         assertEquals(4, ldm.getLabels().size());
         assertEquals(4, ldm.getMatrix().length);

--- a/web/src/test/java/com/chatalytics/web/resources/EntitiesResourceTest.java
+++ b/web/src/test/java/com/chatalytics/web/resources/EntitiesResourceTest.java
@@ -138,6 +138,22 @@ public class EntitiesResourceTest {
         assertEquals(4, ldm.getMatrix().length);
     }
 
+    /**
+     * Tests the similarities endpoint
+     */
+    @Test
+    public void testGetSimilarities_UserByEntity() throws Exception {
+        DateTimeFormatter dtf = DateTimeUtils.PARAMETER_WITH_DAY_DTF.withZone(dtZone);
+        String startTimeStr = dtf.print(mentionTime.minusDays(1));
+        String endTimeStr = dtf.print(mentionTime.plusDays(1));
+
+        LabeledDenseMatrix<String> ldm = underTest.getSimilarities(
+                startTimeStr, endTimeStr, DimensionType.USER.getDimensionName(),
+                DimensionType.ENTITY.getDimensionName());
+        assertEquals(4, ldm.getLabels().size());
+        assertEquals(4, ldm.getMatrix().length);
+    }
+
     @Test(expected = UnsupportedOperationException.class)
     public void testGetSimilarities_badCombination() throws Exception {
         DateTimeFormatter dtf = DateTimeUtils.PARAMETER_WITH_DAY_DTF.withZone(dtZone);


### PR DESCRIPTION
- The emoji and entity DAOs only used to expose the room similarities method but now they also expose the user one too. Both of these methods delegate to the MentionableDAO
- Update tests and rename the emoji room similarity to say emoji and not entity
