### PR TITLE
Generalize getTotalMentions and getAllMentions

### DIFF
--- a/compute/src/main/java/com/chatalytics/compute/db/dao/EmojiDAOImpl.java
+++ b/compute/src/main/java/com/chatalytics/compute/db/dao/EmojiDAOImpl.java
@@ -3,7 +3,6 @@ package com.chatalytics.compute.db.dao;
 import com.chatalytics.compute.matrix.LabeledDenseMatrix;
 import com.chatalytics.core.ActiveMethod;
 import com.chatalytics.core.model.data.EmojiEntity;
-import com.google.common.base.Optional;
 import com.google.common.util.concurrent.AbstractIdleService;
 
 import org.joda.time.Interval;
@@ -59,9 +58,9 @@ public class EmojiDAOImpl extends AbstractIdleService implements IEmojiDAO {
     @Override
     public List<EmojiEntity> getAllMentionsForEmoji(String emoji,
                                                     Interval interval,
-                                                    Optional<String> roomName,
-                                                    Optional<String> username) {
-        return occurrenceStatsDAO.getAllMentionsForValue(emoji, interval, roomName, username);
+                                                    List<String> roomNames,
+                                                    List<String> usernames) {
+        return occurrenceStatsDAO.getAllMentionsForValue(emoji, interval, roomNames, usernames);
     }
 
     /**
@@ -69,9 +68,9 @@ public class EmojiDAOImpl extends AbstractIdleService implements IEmojiDAO {
      */
     @Override
     public List<EmojiEntity> getAllMentions(Interval interval,
-                                            Optional<String> roomName,
-                                            Optional<String> username) {
-        return occurrenceStatsDAO.getAllMentions(interval, roomName, username);
+                                            List<String> roomNames,
+                                            List<String> usernames) {
+        return occurrenceStatsDAO.getAllMentions(interval, roomNames, usernames);
     }
 
 
@@ -81,9 +80,9 @@ public class EmojiDAOImpl extends AbstractIdleService implements IEmojiDAO {
     @Override
     public int getTotalMentionsForEmoji(String emoji,
                                         Interval interval,
-                                        Optional<String> roomName,
-                                        Optional<String> username) {
-        return occurrenceStatsDAO.getTotalMentionsForType(emoji, interval, roomName, username);
+                                        List<String> roomNames,
+                                        List<String> usernames) {
+        return occurrenceStatsDAO.getTotalMentionsForType(emoji, interval, roomNames, usernames);
     }
 
     /**
@@ -91,10 +90,10 @@ public class EmojiDAOImpl extends AbstractIdleService implements IEmojiDAO {
      */
     @Override
     public Map<String, Long> getTopEmojis(Interval interval,
-                                          Optional<String> roomName,
-                                          Optional<String> username,
+                                          List<String> roomNames,
+                                          List<String> usernames,
                                           int resultSize) {
-        return occurrenceStatsDAO.getTopValuesOfType(interval, roomName, username, resultSize);
+        return occurrenceStatsDAO.getTopValuesOfType(interval, roomNames, usernames, resultSize);
     }
 
     /**

--- a/compute/src/main/java/com/chatalytics/compute/db/dao/EntityDAOImpl.java
+++ b/compute/src/main/java/com/chatalytics/compute/db/dao/EntityDAOImpl.java
@@ -3,7 +3,6 @@ package com.chatalytics.compute.db.dao;
 import com.chatalytics.compute.matrix.LabeledDenseMatrix;
 import com.chatalytics.core.ActiveMethod;
 import com.chatalytics.core.model.data.ChatEntity;
-import com.google.common.base.Optional;
 import com.google.common.util.concurrent.AbstractIdleService;
 
 import org.joda.time.Interval;
@@ -59,9 +58,9 @@ public class EntityDAOImpl extends AbstractIdleService implements IEntityDAO {
     @Override
     public List<ChatEntity> getAllMentionsForEntity(String entity,
                                                     Interval interval,
-                                                    Optional<String> roomName,
-                                                    Optional<String> username) {
-        return occurrenceStatsDAO.getAllMentionsForValue(entity, interval, roomName, username);
+                                                    List<String> roomNames,
+                                                    List<String> usernames) {
+        return occurrenceStatsDAO.getAllMentionsForValue(entity, interval, roomNames, usernames);
     }
 
     /**
@@ -69,9 +68,9 @@ public class EntityDAOImpl extends AbstractIdleService implements IEntityDAO {
      */
     @Override
     public List<ChatEntity> getAllMentions(Interval interval,
-                                           Optional<String> roomName,
-                                           Optional<String> username) {
-        return occurrenceStatsDAO.getAllMentions(interval, roomName, username);
+                                           List<String> roomNames,
+                                           List<String> usernames) {
+        return occurrenceStatsDAO.getAllMentions(interval, roomNames, usernames);
     }
 
     /**
@@ -80,10 +79,10 @@ public class EntityDAOImpl extends AbstractIdleService implements IEntityDAO {
     @Override
     public int getTotalMentionsForEntity(String entity,
                                          Interval interval,
-                                         Optional<String> roomName,
-                                         Optional<String> username) {
+                                         List<String> roomNames,
+                                         List<String> usernames) {
 
-        return occurrenceStatsDAO.getTotalMentionsForType(entity, interval, roomName, username);
+        return occurrenceStatsDAO.getTotalMentionsForType(entity, interval, roomNames, usernames);
     }
 
     /**
@@ -91,11 +90,11 @@ public class EntityDAOImpl extends AbstractIdleService implements IEntityDAO {
      */
     @Override
     public Map<String, Long> getTopEntities(Interval interval,
-                                            Optional<String> roomName,
-                                            Optional<String> username,
+                                            List<String> roomNames,
+                                            List<String> usernames,
                                             int resultSize) {
 
-        return occurrenceStatsDAO.getTopValuesOfType(interval, roomName, username, resultSize);
+        return occurrenceStatsDAO.getTopValuesOfType(interval, roomNames, usernames, resultSize);
     }
 
     /**

--- a/compute/src/main/java/com/chatalytics/compute/db/dao/IEmojiDAO.java
+++ b/compute/src/main/java/com/chatalytics/compute/db/dao/IEmojiDAO.java
@@ -5,7 +5,6 @@ import com.chatalytics.compute.matrix.LabeledDenseMatrix;
 import com.chatalytics.compute.matrix.LabeledMTJMatrix;
 import com.chatalytics.core.ActiveMethod;
 import com.chatalytics.core.model.data.EmojiEntity;
-import com.google.common.base.Optional;
 import com.google.common.util.concurrent.Service;
 
 import org.joda.time.Interval;
@@ -41,17 +40,17 @@ public interface IEmojiDAO extends Service {
      * @param interval
      *            The interval of interest. Note that the query is inclusive of the start time and
      *            exclusive of the end time.
-     * @param roomName
-     *            Optionally supply a room name
-     * @param username
-     *            Optionally supply a user name
+     * @param roomNames
+     *            Optionally supply a list of room names. This list can be empty
+     * @param usernames
+     *            Optionally supply a list of user names. This list can be empty
      * @return A list of {@link EmojiEntity} representing all the times this emoji was mentioned in
      *         the given time period
      */
      List<EmojiEntity> getAllMentionsForEmoji(String emoji,
                                               Interval interval,
-                                              Optional<String> roomName,
-                                              Optional<String> username);
+                                              List<String> roomNames,
+                                              List<String> usernames);
 
     /**
      * Returns all the mention occurrences of all the emojis inside the given <code>interval</code>
@@ -59,14 +58,16 @@ public interface IEmojiDAO extends Service {
      * @param interval
      *            The interval of interest. Note that the query is inclusive of the start time and
      *            exclusive of the end time.
-     * @param roomName Optionally supply a room name
-     * @param username Optionally supply a user name
+     * @param roomNames
+     *            Optionally supply a list of room names. This list can be empty
+     * @param usernames
+     *            Optionally supply a list of user names. This list can be empty
      * @return A list of {@link EmojiEntity} representing all the times emojis were mentioned in the
      *         given time period
      */
      List<EmojiEntity> getAllMentions(Interval interval,
-                                      Optional<String> roomName,
-                                      Optional<String> username);
+                                      List<String> roomNames,
+                                      List<String> usernames);
 
     /**
      * Returns the total number of times an emoji was mentioned in the given <code>interval</code>.
@@ -76,16 +77,16 @@ public interface IEmojiDAO extends Service {
      * @param interval
      *            The interval of interest. Note that the query is inclusive of the start time and
      *            exclusive of the end time.
-     * @param roomName
-     *            Optionally supply a room name
-     * @param username
-     *            Optionally supply a user name
+     * @param roomNames
+     *            Optionally supply a list of room names. This list can be empty
+     * @param usernames
+     *            Optionally supply a list of user names. This list can be empty
      * @return The total number of times the emoji was mentioned in the given time interval
      */
      int getTotalMentionsForEmoji(String emoji,
                                   Interval interval,
-                                  Optional<String> roomName,
-                                  Optional<String> username);
+                                  List<String> roomNames,
+                                  List<String> usernames);
 
     /**
      * Returns back the top emojis in the given time interval, and optionally by user name and/or
@@ -93,17 +94,17 @@ public interface IEmojiDAO extends Service {
      *
      * @param interval
      *            The time interval to search in
-     * @param roomName
-     *            Optional room name to filter by
-     * @param username
-     *            Optional user name to filter by
+     * @param roomNames
+     *            Optionally supply a list of room names. This list can be empty
+     * @param usernames
+     *            Optionally supply a list of user names. This list can be empty
      * @param resultSize
      *            The number of top emojis to return back
      * @return Returns back a map of emoji to number of occurrences.
      */
      Map<String, Long> getTopEmojis(Interval interval,
-                                    Optional<String> roomName,
-                                    Optional<String> username,
+                                    List<String> roomNames,
+                                    List<String> usernames,
                                     int resultSize);
 
      /**

--- a/compute/src/main/java/com/chatalytics/compute/db/dao/IEntityDAO.java
+++ b/compute/src/main/java/com/chatalytics/compute/db/dao/IEntityDAO.java
@@ -5,7 +5,6 @@ import com.chatalytics.compute.matrix.LabeledDenseMatrix;
 import com.chatalytics.compute.matrix.LabeledMTJMatrix;
 import com.chatalytics.core.ActiveMethod;
 import com.chatalytics.core.model.data.ChatEntity;
-import com.google.common.base.Optional;
 import com.google.common.util.concurrent.Service;
 
 import org.joda.time.Interval;
@@ -41,34 +40,34 @@ public interface IEntityDAO extends Service {
      * @param interval
      *            The interval of interest. Note that the query is inclusive of the start time and
      *            exclusive of the end time.
-     * @param roomName
-     *            Optionally supply a room name
-     * @param username
-     *            Optionally supply a user name
-     * @return A list of {@link ChatEntity} representing all the times this entity was mentioned
-     *         in the given time period
+     * @param roomNames
+     *            Optionally supply a list of room names. This list can be empty
+     * @param usernames
+     *            Optionally supply a list of user names. This list can be empty
+     * @return A list of {@link ChatEntity} representing all the times this entity was mentioned in
+     *         the given time period
      */
      List<ChatEntity> getAllMentionsForEntity(String entity,
                                               Interval interval,
-                                              Optional<String> roomName,
-                                              Optional<String> username);
+                                              List<String> roomNames,
+                                              List<String> usernames);
 
-     /**
-      * Returns all the mention occurrences for an entity inside the given <code>interval</code>.
-      *
-      * @param interval
-      *            The interval of interest. Note that the query is inclusive of the start time and
-      *            exclusive of the end time.
-      * @param roomName
-      *            Optionally supply a room name
-      * @param username
-      *            Optionally supply a user name
-      * @return A list of {@link ChatEntity} representing all the times this entity was mentioned
-      *         in the given time period
-      */
-      List<ChatEntity> getAllMentions(Interval interval,
-                                      Optional<String> roomName,
-                                      Optional<String> username);
+    /**
+     * Returns all the mention occurrences for an entity inside the given <code>interval</code>.
+     *
+     * @param interval
+     *            The interval of interest. Note that the query is inclusive of the start time and
+     *            exclusive of the end time.
+     * @param roomNames
+     *            Optionally supply a list of room names. This list can be empty
+     * @param usernames
+     *            Optionally supply a list of user names. This list can be empty
+     * @return A list of {@link ChatEntity} representing all the times this entity was mentioned in
+     *         the given time period
+     */
+    List<ChatEntity> getAllMentions(Interval interval,
+                                    List<String> roomNames,
+                                    List<String> usernames);
 
     /**
      * Returns the total number of times an entity was mentioned in the given <code>interval</code>.
@@ -78,16 +77,16 @@ public interface IEntityDAO extends Service {
      * @param interval
      *            The interval of interest. Note that the query is inclusive of the start time and
      *            exclusive of the end time.
-     * @param roomName
-     *            Optionally supply a room name
-     * @param username
-     *            Optionally supply a user name
+     * @param roomNames
+     *            Optionally supply a list of room names. This list can be empty
+     * @param usernames
+     *            Optionally supply a list of user names. This list can be empty
      * @return The total number of times the entity was mentioned in the given time interval
      */
      int getTotalMentionsForEntity(String entity,
                                    Interval interval,
-                                   Optional<String> roomName,
-                                   Optional<String> username);
+                                   List<String> roomNames,
+                                   List<String> usernames);
 
 
     /**
@@ -96,17 +95,17 @@ public interface IEntityDAO extends Service {
      *
      * @param interval
      *            The time interval to search in
-     * @param roomName
-     *            Optional room name to filter by
-     * @param username
-     *            Optional user name to filter by
+     * @param roomNames
+     *            Optionally supply a list of room names. This list can be empty
+     * @param usernames
+     *            Optionally supply a list of user names. This list can be empty
      * @param resultSize
      *            The number of top entities to return back
      * @return Returns back a map of entity value to number of occurrences.
      */
      Map<String, Long> getTopEntities(Interval interval,
-                                      Optional<String> roomName,
-                                      Optional<String> username,
+                                      List<String> roomNames,
+                                      List<String> usernames,
                                       int resultSize);
 
      /**

--- a/compute/src/main/java/com/chatalytics/compute/db/dao/IMentionableDAO.java
+++ b/compute/src/main/java/com/chatalytics/compute/db/dao/IMentionableDAO.java
@@ -4,7 +4,6 @@ import com.chatalytics.compute.matrix.GraphPartition;
 import com.chatalytics.compute.matrix.LabeledDenseMatrix;
 import com.chatalytics.compute.matrix.LabeledMTJMatrix;
 import com.chatalytics.core.model.data.IMentionable;
-import com.google.common.base.Optional;
 
 import org.joda.time.Interval;
 
@@ -60,17 +59,17 @@ public interface IMentionableDAO<K extends Serializable, T extends IMentionable<
      * @param interval
      *            The interval of interest. Note that the query is inclusive of the start time and
      *            exclusive of the end time.
-     * @param roomName
-     *            Optionally supply a room name
-     * @param username
-     *            Optionally supply a user name
+     * @param roomNames
+     *            Optionally supply a list of room names. This list can be empty
+     * @param usernames
+     *            Optionally supply a list of user names. This list can be empty
      * @return A list of <code>T</code> representing all the times this value was mentioned
      *         in the given time period
      */
     List<T> getAllMentionsForValue(K value,
                                    Interval interval,
-                                   Optional<String> roomName,
-                                   Optional<String> username);
+                                   List<String> roomNames,
+                                   List<String> usernames);
 
     /**
      * Returns all the values and all the mention occurrences of type <code>T</code> inside the
@@ -79,14 +78,14 @@ public interface IMentionableDAO<K extends Serializable, T extends IMentionable<
      * @param interval
      *            The interval of interest. Note that the query is inclusive of the start time and
      *            exclusive of the end time.
-     * @param roomName
-     *            Optionally supply a room name
-     * @param username
-     *            Optionally supply a user name
+     * @param roomNames
+     *            Optionally supply a list of room names. This list can be empty
+     * @param usernames
+     *            Optionally supply a list of user names. This list can be empty
      * @return A list of <code>T</code> representing all the times this value was mentioned
      *         in the given time period
      */
-    List<T> getAllMentions(Interval interval, Optional<String> roomName, Optional<String> username);
+    List<T> getAllMentions(Interval interval, List<String> roomNames, List<String> usernames);
 
     /**
      * Returns the total number of times a type <code>T</code> was mentioned in the given
@@ -97,31 +96,31 @@ public interface IMentionableDAO<K extends Serializable, T extends IMentionable<
      * @param interval
      *            The interval of interest. Note that the query is inclusive of the start time and
      *            exclusive of the end time.
-     * @param roomName
-     *            Optionally supply a room name
-     * @param username
-     *            Optionally supply a user name
+     * @param roomNames
+     *            Optionally supply a list of room names. This list can be empty
+     * @param usernames
+     *            Optionally supply a list of user names. This list can be empty
      * @return The total number of times the value was mentioned in the given time interval
      */
     int getTotalMentionsForType(K value,
                                 Interval interval,
-                                Optional<String> roomName,
-                                Optional<String> username);
+                                List<String> roomNames,
+                                List<String> usernames);
 
     /**
      * Returns the total number of mentions of a particular type this DAO represents
      *
      * @param interval
      *            The interval to search in
-     * @param roomName
-     *            Optional room name
-     * @param username
-     *            Optional username
+     * @param roomNames
+     *            Optionally supply a list of room names. This list can be empty
+     * @param usernames
+     *            Optionally supply a list of user names. This list can be empty
      * @return The total number of mentions based on the given parameters
      */
     int getTotalMentionsOfType(Interval interval,
-                               Optional<String> roomName,
-                               Optional<String> username);
+                               List<String> roomNames,
+                               List<String> usernames);
 
     /**
      * Returns back the top mentioned values of a type in the given time <code>interval</code>, and
@@ -129,17 +128,17 @@ public interface IMentionableDAO<K extends Serializable, T extends IMentionable<
      *
      * @param interval
      *            The time interval to search in
-     * @param roomName
-     *            Optional room name to filter by
-     * @param username
-     *            Optional user name to filter by
+     * @param roomNames
+     *            Optionally supply a list of room names. This list can be empty
+     * @param usernames
+     *            Optionally supply a list of user names. This list can be empty
      * @param resultSize
      *            The number of top entities to return back
      * @return Returns back a map of the value of a type to number of occurrences.
      */
     Map<K, Long> getTopValuesOfType(Interval interval,
-                                    Optional<String> roomName,
-                                    Optional<String> username,
+                                    List<String> roomName,
+                                    List<String> username,
                                     int resultSize);
 
     /**

--- a/compute/src/main/java/com/chatalytics/compute/db/dao/IMessageSummaryDAO.java
+++ b/compute/src/main/java/com/chatalytics/compute/db/dao/IMessageSummaryDAO.java
@@ -4,7 +4,6 @@ import com.chatalytics.core.ActiveMethod;
 import com.chatalytics.core.model.data.ChatEntity;
 import com.chatalytics.core.model.data.MessageSummary;
 import com.chatalytics.core.model.data.MessageType;
-import com.google.common.base.Optional;
 import com.google.common.util.concurrent.Service;
 
 import org.joda.time.Interval;
@@ -40,17 +39,17 @@ public interface IMessageSummaryDAO extends Service {
      * @param interval
      *            The interval of interest. Note that the query is inclusive of the start time and
      *            exclusive of the end time.
-     * @param roomName
-     *            Optionally supply a room name
-     * @param username
-     *            Optionally supply a user name
+     * @param roomNames
+     *            Optionally supply a list of room names. This list can be empty
+     * @param usernames
+     *            Optionally supply a list of user names. This list can be empty
      * @return A list of {@link ChatEntity} representing all the times this entity was mentioned in
      *         the given time period
      */
      List<MessageSummary> getAllMessageSummariesForType(MessageType type,
-                                                Interval interval,
-                                                Optional<String> roomName,
-                                                Optional<String> username);
+                                                        Interval interval,
+                                                        List<String> roomNames,
+                                                        List<String> usernames);
 
      /**
       * Returns all the mention occurrences for an entity inside the given <code>interval</code>.
@@ -58,16 +57,16 @@ public interface IMessageSummaryDAO extends Service {
       * @param interval
       *            The interval of interest. Note that the query is inclusive of the start time and
       *            exclusive of the end time.
-      * @param roomName
-      *            Optionally supply a room name
-      * @param username
-      *            Optionally supply a user name
+      * @param roomNames
+     *            Optionally supply a list of room names. This list can be empty
+      * @param usernames
+     *            Optionally supply a list of user names. This list can be empty
       * @return A list of {@link ChatEntity} representing all the times this entity was mentioned
       *         in the given time period
       */
       List<MessageSummary> getAllMessageSummaries(Interval interval,
-                                          Optional<String> roomName,
-                                          Optional<String> username);
+                                                  List<String> roomNames,
+                                                  List<String> usernames);
 
     /**
      * Gets the total number of message summaries in the given time period with username and room
@@ -75,15 +74,15 @@ public interface IMessageSummaryDAO extends Service {
      *
      * @param interval
      *            The time interval to search in
-     * @param roomName
-     *            Optional room name to return count for
-     * @param username
-     *            Optional username to return count for
+     * @param roomNames
+     *            Optionally supply a list of room names. This list can be empty
+     * @param usernames
+     *            Optionally supply a list of user names. This list can be empty
      * @return The total count
      */
     int getTotalMessageSummaries(Interval interval,
-                                 Optional<String> roomName,
-                                 Optional<String> username);
+                                 List<String> roomNames,
+                                 List<String> usernames);
 
     /**
      * Gets the total number of message summaries for a given type in the given time period with
@@ -93,16 +92,16 @@ public interface IMessageSummaryDAO extends Service {
      *            The type to get counts for
      * @param interval
      *            The time interval to search in
-     * @param roomName
-     *            Optional room name to return count for
-     * @param username
-     *            Optional username to return count for
+     * @param roomNames
+     *            Optionally supply a list of room names. This list can be empty
+     * @param usernames
+     *            Optionally supply a list of user names. This list can be empty
      * @return The total count
      */
     int getTotalMessageSummariesForType(MessageType type,
                                         Interval interval,
-                                        Optional<String> roomName,
-                                        Optional<String> username);
+                                        List<String> roomNames,
+                                        List<String> usernames);
 
     /**
      * Returns a sorted map of users to a ratio, where the ratio is one of {@link ActiveMethod}s

--- a/compute/src/main/java/com/chatalytics/compute/db/dao/MessageSummaryDAOImpl.java
+++ b/compute/src/main/java/com/chatalytics/compute/db/dao/MessageSummaryDAOImpl.java
@@ -3,7 +3,6 @@ package com.chatalytics.compute.db.dao;
 import com.chatalytics.core.ActiveMethod;
 import com.chatalytics.core.model.data.MessageSummary;
 import com.chatalytics.core.model.data.MessageType;
-import com.google.common.base.Optional;
 import com.google.common.util.concurrent.AbstractIdleService;
 
 import org.joda.time.Interval;
@@ -58,9 +57,9 @@ public class MessageSummaryDAOImpl extends AbstractIdleService implements IMessa
     @Override
     public List<MessageSummary> getAllMessageSummariesForType(MessageType type,
                                                               Interval interval,
-                                                              Optional<String> roomName,
-                                                              Optional<String> username) {
-        return occurrenceStatsDAO.getAllMentionsForValue(type, interval, roomName, username);
+                                                              List<String> roomNames,
+                                                              List<String> usernames) {
+        return occurrenceStatsDAO.getAllMentionsForValue(type, interval, roomNames, usernames);
     }
 
     /**
@@ -68,18 +67,18 @@ public class MessageSummaryDAOImpl extends AbstractIdleService implements IMessa
      */
     @Override
     public List<MessageSummary> getAllMessageSummaries(Interval interval,
-                                                       Optional<String> roomName,
-                                                       Optional<String> username) {
-        return occurrenceStatsDAO.getAllMentions(interval, roomName, username);
+                                                       List<String> roomNames,
+                                                       List<String> usernames) {
+        return occurrenceStatsDAO.getAllMentions(interval, roomNames, usernames);
     }
 
     /**
      * {@inheritDoc}
      */
     @Override
-    public int getTotalMessageSummaries(Interval interval, Optional<String> roomName,
-                                        Optional<String> username) {
-        return occurrenceStatsDAO.getTotalMentionsOfType(interval, roomName, username);
+    public int getTotalMessageSummaries(Interval interval, List<String> roomNames,
+                                        List<String> usernames) {
+        return occurrenceStatsDAO.getTotalMentionsOfType(interval, roomNames, usernames);
     }
 
     /**
@@ -88,9 +87,9 @@ public class MessageSummaryDAOImpl extends AbstractIdleService implements IMessa
     @Override
     public int getTotalMessageSummariesForType(MessageType type,
                                                Interval interval,
-                                               Optional<String> roomName,
-                                               Optional<String> username) {
-        return occurrenceStatsDAO.getTotalMentionsForType(type, interval, roomName, username);
+                                               List<String> roomNames,
+                                               List<String> usernames) {
+        return occurrenceStatsDAO.getTotalMentionsForType(type, interval, roomNames, usernames);
     }
 
     @Override

--- a/compute/src/test/java/com/chatalytics/compute/db/dao/EmojiDAOImplTest.java
+++ b/compute/src/test/java/com/chatalytics/compute/db/dao/EmojiDAOImplTest.java
@@ -6,7 +6,7 @@ import com.chatalytics.core.config.ChatAlyticsConfig;
 import com.chatalytics.core.model.data.EmojiEntity;
 import com.chatalytics.core.model.data.MessageSummary;
 import com.chatalytics.core.model.data.MessageType;
-import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableList;
 
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
@@ -82,20 +82,21 @@ public class EmojiDAOImplTest {
         // Make sure that 0 is returned when nothing is found
         assertEquals(0, underTest.getTotalMentionsForEmoji("unknownemoji",
                                                            timeInterval,
-                                                           Optional.absent(),
-                                                           Optional.absent()));
+                                                           ImmutableList.of(),
+                                                           ImmutableList.of()));
 
         // make sure that the sums are correct for a bunch of different queries
         int result = underTest.getTotalMentionsForEmoji("emoji1", timeInterval,
-                                                        Optional.absent(), Optional.absent());
+                                                        ImmutableList.of(), ImmutableList.of());
         assertEquals(3, result);
 
         result = underTest.getTotalMentionsForEmoji("emoji1", timeInterval,
-                                                    Optional.of("room1"), Optional.absent());
+                                                    ImmutableList.of("room1"), ImmutableList.of());
         assertEquals(2, result);
 
         result = underTest.getTotalMentionsForEmoji("emoji1", timeInterval,
-                                                    Optional.of("room1"), Optional.of("giannis"));
+                                                    ImmutableList.of("room1"),
+                                                    ImmutableList.of("giannis"));
         assertEquals(1, result);
     }
 
@@ -106,16 +107,16 @@ public class EmojiDAOImplTest {
     public void testGetAllMentionsForEmoji() {
         Interval timeInterval = new Interval(mentionDate, mentionDate.plusHours(3));
         List<EmojiEntity> result = underTest.getAllMentionsForEmoji("emoji1", timeInterval,
-                                                                   Optional.absent(),
-                                                                   Optional.absent());
+                                                                   ImmutableList.of(),
+                                                                   ImmutableList.of());
         assertEquals(3, result.size());
 
-        result = underTest.getAllMentionsForEmoji("emoji1", timeInterval, Optional.of("room1"),
-                                                  Optional.absent());
+        result = underTest.getAllMentionsForEmoji("emoji1", timeInterval, ImmutableList.of("room1"),
+                                                  ImmutableList.of());
         assertEquals(2, result.size());
 
-        result = underTest.getAllMentionsForEmoji("emoji1", timeInterval, Optional.of("room1"),
-                                                  Optional.of("giannis"));
+        result = underTest.getAllMentionsForEmoji("emoji1", timeInterval, ImmutableList.of("room1"),
+                                                  ImmutableList.of("giannis"));
         assertEquals(1, result.size());
     }
 
@@ -125,34 +126,36 @@ public class EmojiDAOImplTest {
     @Test
     public void testGetAllMentions() {
         Interval timeInterval = new Interval(mentionDate, mentionDate.plusHours(3));
-        List<EmojiEntity> result = underTest.getAllMentions(timeInterval, Optional.absent(),
-                                                            Optional.absent());
+        List<EmojiEntity> result = underTest.getAllMentions(timeInterval, ImmutableList.of(),
+                                                            ImmutableList.of());
         assertEquals(4, result.size());
 
-        result = underTest.getAllMentions(timeInterval, Optional.of("room1"), Optional.absent());
+        result = underTest.getAllMentions(timeInterval, ImmutableList.of("room1"),
+                                          ImmutableList.of());
         assertEquals(3, result.size());
 
-        result = underTest.getAllMentions(timeInterval, Optional.of("room1"),
-                                          Optional.of("giannis"));
+        result = underTest.getAllMentions(timeInterval, ImmutableList.of("room1"),
+                                          ImmutableList.of("giannis"));
         assertEquals(2, result.size());
     }
 
     @Test
     public void testGetTopEmojis() {
         Interval timeInterval = new Interval(mentionDate, mentionDate.plusHours(3));
-        Map<String, Long> result = underTest.getTopEmojis(timeInterval, Optional.absent(),
-                                                          Optional.absent(), 10);
+        Map<String, Long> result = underTest.getTopEmojis(timeInterval, ImmutableList.of(),
+                                                          ImmutableList.of(), 10);
         assertEquals(2, result.size());
         assertEquals(3L, result.get("emoji1").longValue());
         assertEquals(1L, result.get("emoji2").longValue());
 
-        result = underTest.getTopEmojis(timeInterval, Optional.of("room1"), Optional.absent(), 10);
+        result = underTest.getTopEmojis(timeInterval, ImmutableList.of("room1"), ImmutableList.of(),
+                                        10);
         assertEquals(2, result.size());
         assertEquals(2L, result.get("emoji1").longValue());
         assertEquals(1L, result.get("emoji2").longValue());
 
-        result = underTest.getTopEmojis(timeInterval, Optional.of("room1"), Optional.of("giannis"),
-                                        10);
+        result = underTest.getTopEmojis(timeInterval, ImmutableList.of("room1"),
+                                        ImmutableList.of("giannis"), 10);
         assertEquals(2, result.size());
         assertEquals(1L, result.get("emoji1").longValue());
         assertEquals(1L, result.get("emoji2").longValue());
@@ -178,7 +181,8 @@ public class EmojiDAOImplTest {
     public void testGetActiveRoomsByMethod() {
         Interval interval = new Interval(mentionDate.minusMillis(1), mentionDate.plusMillis(1));
 
-        Map<String, Double> result = underTest.getActiveRoomsByMethod(interval, ActiveMethod.ToTV, 10);
+        Map<String, Double> result = underTest.getActiveRoomsByMethod(interval, ActiveMethod.ToTV,
+                                                                      10);
         assertEquals(2, result.size());
         assertEquals(0.75, result.get("room1"), 0);
         assertEquals(0.25, result.get("room2"), 0);

--- a/compute/src/test/java/com/chatalytics/compute/db/dao/EntityDAOImplTest.java
+++ b/compute/src/test/java/com/chatalytics/compute/db/dao/EntityDAOImplTest.java
@@ -6,7 +6,7 @@ import com.chatalytics.core.config.ChatAlyticsConfig;
 import com.chatalytics.core.model.data.ChatEntity;
 import com.chatalytics.core.model.data.MessageSummary;
 import com.chatalytics.core.model.data.MessageType;
-import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableList;
 
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
@@ -82,20 +82,21 @@ public class EntityDAOImplTest {
         // Make sure that 0 is returned when nothing is found
         assertEquals(0, underTest.getTotalMentionsForEntity("unknownentity",
                                                             timeInterval,
-                                                            Optional.absent(),
-                                                            Optional.absent()));
+                                                            ImmutableList.of(),
+                                                            ImmutableList.of()));
 
         // make sure that the sums are correct for a bunch of different queries
         int result = underTest.getTotalMentionsForEntity("entity1", timeInterval,
-                                                          Optional.absent(), Optional.absent());
+                                                          ImmutableList.of(), ImmutableList.of());
         assertEquals(3, result);
 
         result = underTest.getTotalMentionsForEntity("entity1", timeInterval,
-                                                     Optional.of("room1"), Optional.absent());
+                                                     ImmutableList.of("room1"), ImmutableList.of());
         assertEquals(2, result);
 
         result = underTest.getTotalMentionsForEntity("entity1", timeInterval,
-                                                     Optional.of("room1"), Optional.of("giannis"));
+                                                     ImmutableList.of("room1"),
+                                                     ImmutableList.of("giannis"));
         assertEquals(1, result);
     }
 
@@ -106,16 +107,17 @@ public class EntityDAOImplTest {
     public void testGetAllMentionsForEntity() {
         Interval timeInterval = new Interval(mentionDate, mentionDate.plusHours(3));
         List<ChatEntity> result = underTest.getAllMentionsForEntity("entity1", timeInterval,
-                                                                    Optional.absent(),
-                                                                    Optional.absent());
+                                                                    ImmutableList.of(),
+                                                                    ImmutableList.of());
         assertEquals(3, result.size());
 
-        result = underTest.getAllMentionsForEntity("entity1", timeInterval, Optional.of("room1"),
-                                                Optional.absent());
+        result = underTest.getAllMentionsForEntity("entity1", timeInterval,
+                                                   ImmutableList.of("room1"), ImmutableList.of());
         assertEquals(2, result.size());
 
-        result = underTest.getAllMentionsForEntity("entity1", timeInterval, Optional.of("room1"),
-                                                Optional.of("giannis"));
+        result = underTest.getAllMentionsForEntity("entity1", timeInterval,
+                                                   ImmutableList.of("room1"),
+                                                   ImmutableList.of("giannis"));
         assertEquals(1, result.size());
     }
 
@@ -125,15 +127,16 @@ public class EntityDAOImplTest {
     @Test
     public void testGetAllMentions() {
         Interval timeInterval = new Interval(mentionDate, mentionDate.plusHours(3));
-        List<ChatEntity> result = underTest.getAllMentions(timeInterval, Optional.absent(),
-                                                           Optional.absent());
+        List<ChatEntity> result = underTest.getAllMentions(timeInterval, ImmutableList.of(),
+                                                           ImmutableList.of());
         assertEquals(4, result.size());
 
-        result = underTest.getAllMentions(timeInterval, Optional.of("room1"), Optional.absent());
+        result = underTest.getAllMentions(timeInterval, ImmutableList.of("room1"),
+                                          ImmutableList.of());
         assertEquals(3, result.size());
 
-        result = underTest.getAllMentions(timeInterval, Optional.of("room1"),
-                                          Optional.of("giannis"));
+        result = underTest.getAllMentions(timeInterval, ImmutableList.of("room1"),
+                                          ImmutableList.of("giannis"));
         assertEquals(2, result.size());
     }
 
@@ -141,19 +144,19 @@ public class EntityDAOImplTest {
     public void testGetTopEntities() {
         Interval timeInterval = new Interval(mentionDate, mentionDate.plusHours(3));
         Map<String, Long> result =
-            underTest.getTopEntities(timeInterval, Optional.absent(), Optional.absent(), 10);
+            underTest.getTopEntities(timeInterval, ImmutableList.of(), ImmutableList.of(), 10);
         assertEquals(2, result.size());
         assertEquals(3L, result.get("entity1").longValue());
         assertEquals(1L, result.get("entity2").longValue());
 
-        result = underTest.getTopEntities(timeInterval, Optional.of("room1"), Optional.absent(),
-                                          10);
+        result = underTest.getTopEntities(timeInterval, ImmutableList.of("room1"),
+                                          ImmutableList.of(), 10);
         assertEquals(2, result.size());
         assertEquals(2L, result.get("entity1").longValue());
         assertEquals(1L, result.get("entity2").longValue());
 
-        result = underTest.getTopEntities(timeInterval, Optional.of("room1"),
-                                          Optional.of("giannis"), 10);
+        result = underTest.getTopEntities(timeInterval, ImmutableList.of("room1"),
+                                          ImmutableList.of("giannis"), 10);
         assertEquals(2, result.size());
         assertEquals(1L, result.get("entity1").longValue());
         assertEquals(1L, result.get("entity2").longValue());

--- a/compute/src/test/java/com/chatalytics/compute/db/dao/MentionableDAOTest.java
+++ b/compute/src/test/java/com/chatalytics/compute/db/dao/MentionableDAOTest.java
@@ -5,7 +5,7 @@ import com.chatalytics.core.config.ChatAlyticsConfig;
 import com.chatalytics.core.model.data.EmojiEntity;
 import com.chatalytics.core.model.data.MessageSummary;
 import com.chatalytics.core.model.data.MessageType;
-import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableList;
 
 import org.joda.time.DateTime;
 import org.joda.time.Interval;
@@ -110,18 +110,33 @@ public class MentionableDAOTest {
         underTest.persistValue(new EmojiEntity("b", 1, start.plusMillis(4), "u2", "r3"));
         underTest.persistValue(new EmojiEntity("c", 1, start.plusMillis(5), "u1", "r3"));
 
-        int result = underTest.getTotalMentionsOfType(interval, Optional.absent(),
-                                                      Optional.absent());
+        int result = underTest.getTotalMentionsOfType(interval, ImmutableList.of(),
+                                                      ImmutableList.of());
         assertEquals(6, result);
 
-        result = underTest.getTotalMentionsOfType(interval, Optional.of("r1"), Optional.absent());
+        result = underTest.getTotalMentionsOfType(interval, ImmutableList.of("r1"),
+                                                  ImmutableList.of());
         assertEquals(2, result);
-
-        result = underTest.getTotalMentionsOfType(interval, Optional.absent(), Optional.of("u1"));
+        result = underTest.getTotalMentionsOfType(interval, ImmutableList.of("r1", "r2"),
+                                                  ImmutableList.of());
         assertEquals(4, result);
 
-        result = underTest.getTotalMentionsOfType(interval, Optional.of("r1"), Optional.of("u1"));
+        result = underTest.getTotalMentionsOfType(interval, ImmutableList.of(),
+                                                  ImmutableList.of("u1"));
+        assertEquals(4, result);
+        result = underTest.getTotalMentionsOfType(interval, ImmutableList.of(),
+                                                  ImmutableList.of("u1", "u2"));
+        assertEquals(6, result);
+
+        result = underTest.getTotalMentionsOfType(interval, ImmutableList.of("r1"),
+                                                  ImmutableList.of("u1"));
         assertEquals(1, result);
+        result = underTest.getTotalMentionsOfType(interval, ImmutableList.of("r1", "r2"),
+                                                  ImmutableList.of("u1"));
+        result = underTest.getTotalMentionsOfType(interval, ImmutableList.of("r1", "r2"),
+                                                  ImmutableList.of("u1", "u2"));
+
+        assertEquals(4, result);
     }
 
     @Test
@@ -135,17 +150,24 @@ public class MentionableDAOTest {
         underTest.persistValue(new EmojiEntity("b", 1, start.plusMillis(3), "u1", "r2"));
         underTest.persistValue(new EmojiEntity("c", 1, start.plusMillis(5), "u1", "r3"));
 
-        int result = underTest.getTotalMentionsForType("a", interval, Optional.absent(),
-                                                       Optional.absent());
+        int result = underTest.getTotalMentionsForType("a", interval, ImmutableList.of(),
+                                                       ImmutableList.of());
         assertEquals(3, result);
 
-        result = underTest.getTotalMentionsForType("a", interval, Optional.of("r1"),
-                                                   Optional.absent());
+        result = underTest.getTotalMentionsForType("a", interval, ImmutableList.of("r1"),
+                                                   ImmutableList.of());
         assertEquals(1, result);
-
-        result = underTest.getTotalMentionsForType("a", interval, Optional.absent(),
-                                                   Optional.of("u1"));
+        result = underTest.getTotalMentionsForType("a", interval, ImmutableList.of("r1", "r2"),
+                                                   ImmutableList.of());
         assertEquals(2, result);
+
+        result = underTest.getTotalMentionsForType("a", interval, ImmutableList.of(),
+                                                   ImmutableList.of("u1"));
+        assertEquals(2, result);
+        result = underTest.getTotalMentionsForType("a", interval, ImmutableList.of(),
+                                                   ImmutableList.of("u1", "u2"));
+        assertEquals(3, result);
+
     }
 
     @Test

--- a/compute/src/test/java/com/chatalytics/compute/db/dao/MessageSummaryDAOImplTest.java
+++ b/compute/src/test/java/com/chatalytics/compute/db/dao/MessageSummaryDAOImplTest.java
@@ -4,7 +4,7 @@ import com.chatalytics.core.ActiveMethod;
 import com.chatalytics.core.config.ChatAlyticsConfig;
 import com.chatalytics.core.model.data.MessageSummary;
 import com.chatalytics.core.model.data.MessageType;
-import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableList;
 
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
@@ -84,8 +84,8 @@ public class MessageSummaryDAOImplTest {
     public void testGetAllMessageSummaries() {
         Interval interval = new Interval(mentionDate.minusDays(1),  mentionDate.plusDays(1));
         List<MessageSummary> result = underTest.getAllMessageSummaries(interval,
-                                                                       Optional.of("room1"),
-                                                                       Optional.of("user1"));
+                                                                       ImmutableList.of("room1"),
+                                                                       ImmutableList.of("user1"));
         assertEquals(1, result.size());
     }
 
@@ -94,16 +94,16 @@ public class MessageSummaryDAOImplTest {
         Interval interval = new Interval(mentionDate.minusDays(1),  mentionDate.plusDays(1));
         List<MessageSummary> result = underTest.getAllMessageSummariesForType(MessageType.MESSAGE,
                                                                               interval,
-                                                                              Optional.absent(),
-                                                                              Optional.absent());
+                                                                              ImmutableList.of(),
+                                                                              ImmutableList.of());
         assertEquals(2, result.size());
     }
 
     @Test
     public void testGetTotalMessageSummaries() {
         Interval interval = new Interval(mentionDate.minusDays(1),  mentionDate.plusDays(1));
-        int result = underTest.getTotalMessageSummaries(interval, Optional.absent(),
-                                                        Optional.absent());
+        int result = underTest.getTotalMessageSummaries(interval, ImmutableList.of(),
+                                                        ImmutableList.of());
         assertEquals(4, result);
     }
 
@@ -111,8 +111,8 @@ public class MessageSummaryDAOImplTest {
     public void testGetTotalMessageSummariesForType_withValue() {
         Interval interval = new Interval(mentionDate.minusDays(1),  mentionDate.plusDays(1));
         int result = underTest.getTotalMessageSummariesForType(MessageType.MESSAGE,
-                                                        interval, Optional.absent(),
-                                                        Optional.absent());
+                                                        interval, ImmutableList.of(),
+                                                        ImmutableList.of());
         assertEquals(2, result);
     }
 

--- a/web/src/main/java/com/chatalytics/web/resources/EmojisResource.java
+++ b/web/src/main/java/com/chatalytics/web/resources/EmojisResource.java
@@ -83,36 +83,35 @@ public class EmojisResource {
     @Produces(MediaType.APPLICATION_JSON)
     public Map<String, Long> getTopEmojis(@QueryParam(START_TIME) String startTimeStr,
                                  @QueryParam(END_TIME) String endTimeStr,
-                                 @QueryParam(USER) String user,
-                                 @QueryParam(ROOM) String room,
+                                 @QueryParam(USER) List<String> users,
+                                 @QueryParam(ROOM) List<String> rooms,
                                  @QueryParam(TOP_N) String topNStr)
                     throws JsonGenerationException, JsonMappingException, IOException {
 
-        LOG.debug("Got query for starttime={}, endtime={}, user={}, room={}",
-                  startTimeStr, endTimeStr, user, room);
+        LOG.debug("Got query for starttime={}, endtime={}, users={}, rooms={}",
+                  startTimeStr, endTimeStr, users, rooms);
 
-        Optional<String> username = ResourceUtils.getOptionalForParameter(user);
-        Optional<String> roomName = ResourceUtils.getOptionalForParameter(room);
+        users = ResourceUtils.getListFromNullable(users);
+        rooms = ResourceUtils.getListFromNullable(rooms);
         Optional<Integer> topN = ResourceUtils.getOptionalForParameterAsInt(topNStr);
 
         Interval interval = DateTimeUtils.getIntervalFromParameters(startTimeStr, endTimeStr, dtz);
 
-        return emojiDao.getTopEmojis(interval, roomName, username, topN.or(MAX_RESULTS));
+        return emojiDao.getTopEmojis(interval, rooms, users, topN.or(MAX_RESULTS));
     }
 
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     public List<EmojiEntity> getAllEmojis(@QueryParam(START_TIME) String startTimeStr,
                                           @QueryParam(END_TIME) String endTimeStr,
-                                          @QueryParam(USER) String user,
-                                          @QueryParam(ROOM) String room) {
-
-        Optional<String> username = ResourceUtils.getOptionalForParameter(user);
-        Optional<String> roomName = ResourceUtils.getOptionalForParameter(room);
+                                          @QueryParam(USER) List<String> users,
+                                          @QueryParam(ROOM) List<String> rooms) {
 
         Interval interval = DateTimeUtils.getIntervalFromParameters(startTimeStr, endTimeStr, dtz);
+        users = ResourceUtils.getListFromNullable(users);
+        rooms = ResourceUtils.getListFromNullable(rooms);
 
-        return emojiDao.getAllMentions(interval, roomName, username);
+        return emojiDao.getAllMentions(interval, rooms, users);
     }
 
     @GET

--- a/web/src/main/java/com/chatalytics/web/resources/EntitiesResource.java
+++ b/web/src/main/java/com/chatalytics/web/resources/EntitiesResource.java
@@ -66,37 +66,37 @@ public class EntitiesResource {
     @Produces(MediaType.APPLICATION_JSON)
     public Map<String, Long> getTrendingTopics(@QueryParam(START_TIME) String startTimeStr,
                                                @QueryParam(END_TIME) String endTimeStr,
-                                               @QueryParam(USER) String user,
-                                               @QueryParam(ROOM) String room,
+                                               @QueryParam(USER) List<String> users,
+                                               @QueryParam(ROOM) List<String> rooms,
                                                @QueryParam(TOP_N) String topNStr)
                     throws JsonGenerationException, JsonMappingException, IOException {
 
-        LOG.debug("Got trending topics query for starttime={}, endtime={}, user={}, room={}",
-                  startTimeStr, endTimeStr, user, room);
+        LOG.debug("Got trending topics query for starttime={}, endtime={}, users={}, rooms={}",
+                  startTimeStr, endTimeStr, users, rooms);
 
-        Optional<String> username = ResourceUtils.getOptionalForParameter(user);
-        Optional<String> roomName = ResourceUtils.getOptionalForParameter(room);
         Optional<Integer> topN = ResourceUtils.getOptionalForParameterAsInt(topNStr);
         Interval interval = DateTimeUtils.getIntervalFromParameters(startTimeStr, endTimeStr, dtz);
+        users = ResourceUtils.getListFromNullable(users);
+        rooms = ResourceUtils.getListFromNullable(rooms);
 
-        return entityDao.getTopEntities(interval, roomName, username, topN.or(MAX_RESULTS));
+        return entityDao.getTopEntities(interval, rooms, users, topN.or(MAX_RESULTS));
     }
 
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     public List<ChatEntity> getAllEntites(@QueryParam(START_TIME) String startTimeStr,
                                           @QueryParam(END_TIME) String endTimeStr,
-                                          @QueryParam(USER) String user,
-                                          @QueryParam(ROOM) String room) {
+                                          @QueryParam(USER) List<String> users,
+                                          @QueryParam(ROOM) List<String> rooms) {
 
-        LOG.debug("Got all entities query for starttime={}, endtime={}, user={}, room={}",
-                  startTimeStr, endTimeStr, user, room);
+        LOG.debug("Got all entities query for starttime={}, endtime={}, users={}, rooms={}",
+                  startTimeStr, endTimeStr, users, rooms);
 
-        Optional<String> username = ResourceUtils.getOptionalForParameter(user);
-        Optional<String> roomName = ResourceUtils.getOptionalForParameter(room);
         Interval interval = DateTimeUtils.getIntervalFromParameters(startTimeStr, endTimeStr, dtz);
+        users = ResourceUtils.getListFromNullable(users);
+        rooms = ResourceUtils.getListFromNullable(rooms);
 
-        return entityDao.getAllMentions(interval, roomName, username);
+        return entityDao.getAllMentions(interval, rooms, users);
     }
 
     @GET

--- a/web/src/main/java/com/chatalytics/web/resources/MessageSummaryResource.java
+++ b/web/src/main/java/com/chatalytics/web/resources/MessageSummaryResource.java
@@ -65,9 +65,9 @@ public class MessageSummaryResource {
      *            The start time to get the summaries for
      * @param endTimeStr
      *            The end time to get the summaries for
-     * @param user
+     * @param users
      *            The user to query for (optional)
-     * @param room
+     * @param rooms
      *            The room to query for (optional)
      * @param msgTypeStr
      *            The type of the message. See {@link MessageType} for more info (optional)
@@ -77,23 +77,23 @@ public class MessageSummaryResource {
     @Produces(MediaType.APPLICATION_JSON)
     public List<MessageSummary> getAllMessageSummaries(@QueryParam(START_TIME) String startTimeStr,
                                                        @QueryParam(END_TIME) String endTimeStr,
-                                                       @QueryParam(USER) String user,
-                                                       @QueryParam(ROOM) String room,
+                                                       @QueryParam(USER) List<String> users,
+                                                       @QueryParam(ROOM) List<String> rooms,
                                                        @QueryParam(MESSAGE_TYPE) String msgTypeStr) {
 
-        LOG.debug("Got a call for msg summaries with starttime={} endtime={} user={} room={}",
-                  startTimeStr, endTimeStr, user, room);
+        LOG.debug("Got a call for msg summaries with starttime={} endtime={} users={} rooms={}",
+                  startTimeStr, endTimeStr, users, rooms);
 
         Interval interval = DateTimeUtils.getIntervalFromParameters(startTimeStr, endTimeStr, dtz);
-        Optional<String> username = ResourceUtils.getOptionalForParameter(user);
-        Optional<String> roomName = ResourceUtils.getOptionalForParameter(room);
+        users = ResourceUtils.getListFromNullable(users);
+        rooms = ResourceUtils.getListFromNullable(rooms);
+
         Optional<String> optMessageType = ResourceUtils.getOptionalForParameter(msgTypeStr);
         if (optMessageType.isPresent()) {
             MessageType msgType = MessageType.fromType(optMessageType.get());
-            return msgSummaryDao.getAllMessageSummariesForType(msgType, interval, roomName,
-                                                               username);
+            return msgSummaryDao.getAllMessageSummariesForType(msgType, interval, rooms, users);
         } else {
-            return msgSummaryDao.getAllMessageSummaries(interval, roomName, username);
+            return msgSummaryDao.getAllMessageSummaries(interval, rooms, users);
         }
     }
 
@@ -105,9 +105,9 @@ public class MessageSummaryResource {
      *            The start time to get the summaries for
      * @param endTimeStr
      *            The end time to get the summaries for
-     * @param user
+     * @param users
      *            The user to query for (optional)
-     * @param room
+     * @param rooms
      *            The room to query for (optional)
      * @param msgTypeStr
      *            The type of the message. See {@link MessageType} for more info (optional)
@@ -118,23 +118,22 @@ public class MessageSummaryResource {
     @Produces(MediaType.APPLICATION_JSON)
     public int getTotalMessageSummaries(@QueryParam(START_TIME) String startTimeStr,
                                         @QueryParam(END_TIME) String endTimeStr,
-                                        @QueryParam(USER) String user,
-                                        @QueryParam(ROOM) String room,
+                                        @QueryParam(USER) List<String> users,
+                                        @QueryParam(ROOM) List<String> rooms,
                                         @QueryParam(MESSAGE_TYPE) String msgTypeStr) {
 
-        LOG.debug("Got a call for total msg summaries with starttime={} endtime={} user={} room={}",
-                  startTimeStr, endTimeStr, user, room);
+        LOG.debug("Got total message summaries with starttime={} endtime={} users={} rooms={}",
+                  startTimeStr, endTimeStr, users, rooms);
 
         Interval interval = DateTimeUtils.getIntervalFromParameters(startTimeStr, endTimeStr, dtz);
-        Optional<String> username = ResourceUtils.getOptionalForParameter(user);
-        Optional<String> roomName = ResourceUtils.getOptionalForParameter(room);
+        users = ResourceUtils.getListFromNullable(users);
+        rooms = ResourceUtils.getListFromNullable(rooms);
         Optional<String> optMessageType = ResourceUtils.getOptionalForParameter(msgTypeStr);
         if (optMessageType.isPresent()) {
             MessageType msgType = MessageType.fromType(optMessageType.get());
-            return msgSummaryDao.getTotalMessageSummariesForType(msgType, interval, roomName,
-                                                                 username);
+            return msgSummaryDao.getTotalMessageSummariesForType(msgType, interval, rooms, users);
         } else {
-            return msgSummaryDao.getTotalMessageSummaries(interval, roomName, username);
+            return msgSummaryDao.getTotalMessageSummaries(interval, rooms, users);
         }
     }
 

--- a/web/src/main/java/com/chatalytics/web/utils/ResourceUtils.java
+++ b/web/src/main/java/com/chatalytics/web/utils/ResourceUtils.java
@@ -2,6 +2,12 @@ package com.chatalytics.web.utils;
 
 import com.google.common.base.Optional;
 
+import org.apache.storm.shade.com.google.common.collect.ImmutableList;
+
+import java.util.List;
+
+import javax.annotation.Nullable;
+
 /**
  * Contains utility methods commonly used by resources
  *
@@ -39,6 +45,22 @@ public class ResourceUtils {
             return Optional.absent();
         } else {
             return Optional.of(Integer.parseInt(parameterStr));
+        }
+    }
+
+    /**
+     * Checks to see if the passed in list is null. If it is it creates an empty one. Note that the
+     * empty list it returns is a singleton immutable list
+     *
+     * @param list
+     *            The list to check
+     * @return an empty {@link ImmutableList} if <code>list</code> is null, or list otherwise
+     */
+    public static <T> List<T> getListFromNullable(@Nullable List<T> list) {
+        if (list == null) {
+            return ImmutableList.of();
+        } else {
+            return list;
         }
     }
 

--- a/web/src/test/java/com/chatalytics/web/resources/EmojisResourceTest.java
+++ b/web/src/test/java/com/chatalytics/web/resources/EmojisResourceTest.java
@@ -13,6 +13,7 @@ import com.chatalytics.core.model.data.EmojiEntity;
 import com.chatalytics.core.model.data.EmojiMap;
 import com.chatalytics.web.utils.DateTimeUtils;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
@@ -89,14 +90,17 @@ public class EmojisResourceTest {
         DateTimeFormatter dtf = DateTimeUtils.PARAMETER_WITH_DAY_DTF.withZone(dtZone);
         String startTimeStr = dtf.print(mentionTime.minusDays(1));
         String endTimeStr = dtf.print(mentionTime.plusDays(1));
-        Map<String, Long> response = underTest.getTopEmojis(startTimeStr, endTimeStr, "u1", "r1",
+        Map<String, Long> response = underTest.getTopEmojis(startTimeStr, endTimeStr,
+                                                            ImmutableList.of("u1"),
+                                                            ImmutableList.of("r1"),
                                                             null);
         Map<String, Long> expected = Maps.newHashMap();
         expected.put("e1", 5L);
         expected.put("e2", 1L);
         assertEquals(expected, response);
 
-        response = underTest.getTopEmojis(startTimeStr, endTimeStr, "u1", null, null);
+        response = underTest.getTopEmojis(startTimeStr, endTimeStr, ImmutableList.of("u1"),
+                                          null, null);
         expected.clear();
         expected.put("e1", 5L);
         expected.put("e4", 3L);

--- a/web/src/test/java/com/chatalytics/web/resources/EntitiesResourceTest.java
+++ b/web/src/test/java/com/chatalytics/web/resources/EntitiesResourceTest.java
@@ -8,6 +8,7 @@ import com.chatalytics.core.DimensionType;
 import com.chatalytics.core.config.ChatAlyticsConfig;
 import com.chatalytics.core.model.data.ChatEntity;
 import com.chatalytics.web.utils.DateTimeUtils;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
@@ -84,14 +85,16 @@ public class EntitiesResourceTest {
         DateTimeFormatter dtf = DateTimeUtils.PARAMETER_WITH_DAY_DTF.withZone(dtZone);
         String startTimeStr = dtf.print(mentionTime.minusDays(1));
         String endTimeStr = dtf.print(mentionTime.plusDays(1));
-        Map<String, Long> response = underTest.getTrendingTopics(startTimeStr, endTimeStr, "u1",
-                                                                 "r1", null);
+        Map<String, Long> response = underTest.getTrendingTopics(startTimeStr, endTimeStr,
+                                                                 ImmutableList.of("u1"),
+                                                                 ImmutableList.of("r1"), null);
         Map<String, Long> expected = Maps.newHashMap();
         expected.put("e1", 5L);
         expected.put("e2", 1L);
         assertEquals(expected, response);
 
-        response = underTest.getTrendingTopics(startTimeStr, endTimeStr, "u1", null, null);
+        response = underTest.getTrendingTopics(startTimeStr, endTimeStr, ImmutableList.of("u1"),
+                                               null, null);
         expected.clear();
         expected.put("e1", 5L);
         expected.put("e4", 3L);

--- a/web/src/test/java/com/chatalytics/web/resources/MessageSummaryResourceTest.java
+++ b/web/src/test/java/com/chatalytics/web/resources/MessageSummaryResourceTest.java
@@ -8,6 +8,7 @@ import com.chatalytics.core.config.ChatAlyticsConfig;
 import com.chatalytics.core.model.data.MessageSummary;
 import com.chatalytics.core.model.data.MessageType;
 import com.chatalytics.web.utils.DateTimeUtils;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 
@@ -92,10 +93,12 @@ public class MessageSummaryResourceTest {
         int result = underTest.getTotalMessageSummaries(startTimeStr, endTimeStr, null, null, null);
         assertEquals(sums.size(), result);
 
-        result = underTest.getTotalMessageSummaries(startTimeStr, endTimeStr, "u1", null, null);
+        result = underTest.getTotalMessageSummaries(startTimeStr, endTimeStr,
+                                                    ImmutableList.of("u1"), null, null);
         assertEquals(1, result);
 
-        result = underTest.getTotalMessageSummaries(startTimeStr, endTimeStr, null, "r1", null);
+        result = underTest.getTotalMessageSummaries(startTimeStr, endTimeStr, null,
+                                                    ImmutableList.of("r1"), null);
         assertEquals(3, result);
 
         result = underTest.getTotalMessageSummaries(startTimeStr, endTimeStr, null, null,

--- a/web/src/test/java/com/chatalytics/web/utils/ResourceUtilsTest.java
+++ b/web/src/test/java/com/chatalytics/web/utils/ResourceUtilsTest.java
@@ -1,8 +1,12 @@
 package com.chatalytics.web.utils;
 
 import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableList;
 
+import org.apache.storm.shade.com.google.common.collect.Lists;
 import org.junit.Test;
+
+import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 
@@ -25,6 +29,12 @@ public class ResourceUtilsTest {
         String param = "some-param";
         result = ResourceUtils.getOptionalForParameter(param);
         assertEquals(param, result.get());
+    }
 
+    @Test
+    public void testGetListFromNullable() {
+        assertEquals(ImmutableList.of(), ResourceUtils.getListFromNullable(null));
+        List<String> test = Lists.newArrayList("a", "b");
+        assertEquals(test, ResourceUtils.getListFromNullable(test));
     }
 }


### PR DESCRIPTION
- Generalize all the methods in IMentionableDAO that take an optional username and room name to take in a list that could be empty. Propagate all these changes up to the REST endpoints so that they're now able to take in a list of usernames and/or room names to do those kinds of queries
