### PR TITLE
Excluding nulls for similarities, active

### DIFF
--- a/compute/src/main/java/com/chatalytics/compute/db/dao/MentionableDAO.java
+++ b/compute/src/main/java/com/chatalytics/compute/db/dao/MentionableDAO.java
@@ -422,18 +422,18 @@ public class MentionableDAO<K extends Serializable, T extends IMentionable<K>>
         Root<T> totalFrom = totalQuery.from(type);
         totalQuery.select(cb.sum(totalFrom.get("occurrences")));
         Path<DateTime> totalMentionTime = totalFrom.get("mentionTime");
-        Path<String> columnPath = from.get(columnName);
         totalQuery.where(cb.greaterThanOrEqualTo(totalMentionTime, startDateParam),
-                         cb.lessThan(totalMentionTime, endDateParam),
-                         cb.isNotNull(columnPath));
+                         cb.lessThan(totalMentionTime, endDateParam));
 
         // occurrences / total occurrences
         Expression<Double> ratio = cb.quot(cb.sum(occurrences), totalQuery).as(Double.class);
 
+        Path<String> columnPath = from.get(columnName);
         query.multiselect(columnPath, ratio);
         Path<DateTime> mentionTime = from.get("mentionTime");
         query.where(cb.greaterThanOrEqualTo(mentionTime, startDateParam),
-                    cb.lessThan(mentionTime, endDateParam));
+                    cb.lessThan(mentionTime, endDateParam),
+                    cb.isNotNull(columnPath));
         query.groupBy(columnPath);
         query.orderBy(cb.desc(ratio));
         List<Tuple> resultList =
@@ -477,19 +477,18 @@ public class MentionableDAO<K extends Serializable, T extends IMentionable<K>>
         totalQuery.select(cb.sum(totalFrom.get("occurrences")));
         Path<DateTime> totalMentionTime = totalFrom.get("mentionTime");
         Path<MessageType> messageType = totalFrom.get("value");
-        Path<String> columnPath = from.get(columnName);
         totalQuery.where(cb.greaterThanOrEqualTo(totalMentionTime, startDateParam),
                          cb.lessThan(totalMentionTime, endDateParam),
-                         cb.equal(messageType, MessageType.MESSAGE),
-                         cb.isNotNull(columnPath));
+                         cb.equal(messageType, MessageType.MESSAGE));
 
         // occurrences / total occurrences
         Expression<Double> ratio = cb.quot(cb.sum(occurrences), totalQuery).as(Double.class);
+        Path<String> columnPath = from.get(columnName);
 
         query.multiselect(columnPath, ratio);
         Path<DateTime> mentionTime = from.get("mentionTime");
         query.where(cb.greaterThanOrEqualTo(mentionTime, startDateParam),
-                    cb.lessThan(mentionTime, endDateParam));
+                    cb.lessThan(mentionTime, endDateParam), cb.isNotNull(columnPath));
         query.groupBy(columnPath);
         query.orderBy(cb.desc(ratio));
         List<Tuple> resultList =

--- a/compute/src/main/java/com/chatalytics/compute/matrix/GraphPartition.java
+++ b/compute/src/main/java/com/chatalytics/compute/matrix/GraphPartition.java
@@ -19,6 +19,7 @@ import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -73,11 +74,13 @@ public class GraphPartition {
         List<Y> dimYOrd = data.stream()
                               .map(funcY)
                               .distinct()
+                              .filter(Objects::nonNull)
                               .collect(Collectors.toList()); // need ordering
         // column
         List<X> dimXOrd = data.stream()
                               .map(funcX)
                               .distinct()
+                              .filter(Objects::nonNull)
                               .collect(Collectors.toList()); // need ordering
 
         Map<X, Integer> dimXToIdx = IntStream.range(0, dimXOrd.size())
@@ -91,8 +94,15 @@ public class GraphPartition {
         Matrix M = new LinkedSparseMatrix(dimYOrd.size(), dimXOrd.size());
 
         for (T mention : data) {
-            int rowIdx = dimYToIdx.get(funcY.apply(mention));
-            int columnIdx = dimXToIdx.get(funcX.apply(mention));
+            Y yValue = funcY.apply(mention);
+            X xValue = funcX.apply(mention);
+
+            if (yValue == null || xValue == null) {
+                continue;
+            }
+
+            int rowIdx = dimYToIdx.get(yValue);
+            int columnIdx = dimXToIdx.get(xValue);
             double existingValue = M.get(rowIdx, columnIdx);
             M.set(rowIdx, columnIdx, existingValue + mention.getOccurrences());
         }

--- a/compute/src/test/java/com/chatalytics/compute/matrix/GraphPartitionTest.java
+++ b/compute/src/test/java/com/chatalytics/compute/matrix/GraphPartitionTest.java
@@ -23,6 +23,7 @@ import static org.junit.Assert.assertEquals;
  */
 public class GraphPartitionTest {
 
+    @Test
     public void testGetMentionMatrix() {
         List<EmojiEntity> mentions = Lists.newArrayListWithCapacity(16);
         // make r1, r2 and r2 kind of similar
@@ -45,6 +46,24 @@ public class GraphPartitionTest {
         assertEquals(3, result.getMatrix().numRows());
         assertEquals(3, result.getMatrix().numColumns());
         assertEquals(3, result.getLabels().stream().distinct().count());
+    }
+
+    @Test
+    public void testGetMentionMatrix_withNulls() {
+        List<EmojiEntity> mentions = Lists.newArrayListWithCapacity(16);
+        // throw in some null rooms and users
+        mentions.add(new EmojiEntity(null, "r2", DateTime.now().plus(1), "a", 1));
+        mentions.add(new EmojiEntity("u1", null, DateTime.now().plus(2), "a", 1));
+
+        LabeledMTJMatrix<String> result =
+                GraphPartition.getMentionMatrix(mentions,
+                                                mention -> mention.getRoomName(),
+                                                mention -> mention.getUsername());
+
+        // there's three rooms so we expect the size of the matrix to be 3x3 with 3 labels
+        assertEquals(1, result.getMatrix().numRows());
+        assertEquals(1, result.getMatrix().numColumns());
+        assertEquals(1, result.getLabels().stream().distinct().count());
     }
 
     /**


### PR DESCRIPTION
- Exclude null dimension values when computing similarities
- Make active exclude nulls when computing totals for a value
