### PR TITLE
Exposing withBots in all resources and all DAOs

### DIFF
--- a/compute/src/main/java/com/chatalytics/compute/db/dao/EmojiDAOImpl.java
+++ b/compute/src/main/java/com/chatalytics/compute/db/dao/EmojiDAOImpl.java
@@ -59,8 +59,9 @@ public class EmojiDAOImpl extends AbstractIdleService implements IEmojiDAO {
     @Override
     public List<EmojiEntity> getAllMentions(Interval interval,
                                             List<String> roomNames,
-                                            List<String> usernames) {
-        return occurrenceStatsDAO.getAllMentions(interval, roomNames, usernames);
+                                            List<String> usernames,
+                                            boolean withBots) {
+        return occurrenceStatsDAO.getAllMentions(interval, roomNames, usernames, withBots);
     }
 
 
@@ -71,8 +72,10 @@ public class EmojiDAOImpl extends AbstractIdleService implements IEmojiDAO {
     public int getTotalMentionsForEmoji(String emoji,
                                         Interval interval,
                                         List<String> roomNames,
-                                        List<String> usernames) {
-        return occurrenceStatsDAO.getTotalMentionsForType(emoji, interval, roomNames, usernames);
+                                        List<String> usernames,
+                                        boolean withBots) {
+        return occurrenceStatsDAO.getTotalMentionsForType(emoji, interval, roomNames, usernames,
+                                                          withBots);
     }
 
     /**
@@ -82,24 +85,28 @@ public class EmojiDAOImpl extends AbstractIdleService implements IEmojiDAO {
     public Map<String, Long> getTopEmojis(Interval interval,
                                           List<String> roomNames,
                                           List<String> usernames,
-                                          int resultSize) {
-        return occurrenceStatsDAO.getTopValuesOfType(interval, roomNames, usernames, resultSize);
+                                          int resultSize,
+                                          boolean withBots) {
+        return occurrenceStatsDAO.getTopValuesOfType(interval, roomNames, usernames, resultSize,
+                                                     withBots);
     }
 
     /**
      * {@inheritDoc}
      */
     @Override
-    public LabeledDenseMatrix<String> getRoomSimilaritiesByEmoji(Interval interval) {
-        return occurrenceStatsDAO.getRoomSimilaritiesByValue(interval);
+    public LabeledDenseMatrix<String> getRoomSimilaritiesByEmoji(Interval interval,
+                                                                 boolean withBots) {
+        return occurrenceStatsDAO.getRoomSimilaritiesByValue(interval, withBots);
     }
 
     /**
      * {@inheritDoc}
      */
     @Override
-    public LabeledDenseMatrix<String> getUserSimilaritiesByEmoji(Interval interval) {
-        return occurrenceStatsDAO.getUserSimilaritiesByValue(interval);
+    public LabeledDenseMatrix<String> getUserSimilaritiesByEmoji(Interval interval,
+                                                                 boolean withBots) {
+        return occurrenceStatsDAO.getUserSimilaritiesByValue(interval, withBots);
     }
 
     /**
@@ -108,11 +115,14 @@ public class EmojiDAOImpl extends AbstractIdleService implements IEmojiDAO {
     @Override
     public Map<String, Double> getActiveUsersByMethod(Interval interval,
                                                       ActiveMethod method,
-                                                      int resultSize) {
+                                                      int resultSize,
+                                                      boolean withBots) {
         if (method == ActiveMethod.ToTV) {
-            return occurrenceStatsDAO.getActiveColumnsByToTV("username", interval, resultSize);
+            return occurrenceStatsDAO.getActiveColumnsByToTV("username", interval, resultSize,
+                                                             withBots);
         } else if (method == ActiveMethod.ToMV) {
-            return occurrenceStatsDAO.getActiveColumnsByToMV("username", interval, resultSize);
+            return occurrenceStatsDAO.getActiveColumnsByToMV("username", interval, resultSize,
+                                                             withBots);
         } else {
             throw new UnsupportedOperationException(String.format("Method %s not supported",
                                                                   method));
@@ -125,11 +135,14 @@ public class EmojiDAOImpl extends AbstractIdleService implements IEmojiDAO {
     @Override
     public Map<String, Double> getActiveRoomsByMethod(Interval interval,
                                                       ActiveMethod method,
-                                                      int resultSize) {
+                                                      int resultSize,
+                                                      boolean withBots) {
         if (method == ActiveMethod.ToTV) {
-            return occurrenceStatsDAO.getActiveColumnsByToTV("roomName", interval, resultSize);
+            return occurrenceStatsDAO.getActiveColumnsByToTV("roomName", interval, resultSize,
+                                                             withBots);
         } else if (method == ActiveMethod.ToMV) {
-            return occurrenceStatsDAO.getActiveColumnsByToMV("roomName", interval, resultSize);
+            return occurrenceStatsDAO.getActiveColumnsByToMV("roomName", interval, resultSize,
+                                                             withBots);
         } else {
             throw new UnsupportedOperationException(String.format("Method %s not supported",
                                                                   method));

--- a/compute/src/main/java/com/chatalytics/compute/db/dao/EntityDAOImpl.java
+++ b/compute/src/main/java/com/chatalytics/compute/db/dao/EntityDAOImpl.java
@@ -59,8 +59,9 @@ public class EntityDAOImpl extends AbstractIdleService implements IEntityDAO {
     @Override
     public List<ChatEntity> getAllMentions(Interval interval,
                                            List<String> roomNames,
-                                           List<String> usernames) {
-        return occurrenceStatsDAO.getAllMentions(interval, roomNames, usernames);
+                                           List<String> usernames,
+                                           boolean withBots) {
+        return occurrenceStatsDAO.getAllMentions(interval, roomNames, usernames, withBots);
     }
 
     /**
@@ -70,9 +71,11 @@ public class EntityDAOImpl extends AbstractIdleService implements IEntityDAO {
     public int getTotalMentionsForEntity(String entity,
                                          Interval interval,
                                          List<String> roomNames,
-                                         List<String> usernames) {
+                                         List<String> usernames,
+                                         boolean withBots) {
 
-        return occurrenceStatsDAO.getTotalMentionsForType(entity, interval, roomNames, usernames);
+        return occurrenceStatsDAO.getTotalMentionsForType(entity, interval, roomNames, usernames,
+                                                          withBots);
     }
 
     /**
@@ -82,25 +85,29 @@ public class EntityDAOImpl extends AbstractIdleService implements IEntityDAO {
     public Map<String, Long> getTopEntities(Interval interval,
                                             List<String> roomNames,
                                             List<String> usernames,
-                                            int resultSize) {
+                                            int resultSize,
+                                            boolean withBots) {
 
-        return occurrenceStatsDAO.getTopValuesOfType(interval, roomNames, usernames, resultSize);
+        return occurrenceStatsDAO.getTopValuesOfType(interval, roomNames, usernames, resultSize,
+                                                     withBots);
     }
 
     /**
      * {@inheritDoc}
      */
     @Override
-    public LabeledDenseMatrix<String> getRoomSimilaritiesByEntity(Interval interval) {
-        return occurrenceStatsDAO.getRoomSimilaritiesByValue(interval);
+    public LabeledDenseMatrix<String> getRoomSimilaritiesByEntity(Interval interval,
+                                                                  boolean withBots) {
+        return occurrenceStatsDAO.getRoomSimilaritiesByValue(interval, withBots);
     }
 
     /**
      * {@inheritDoc}
      */
     @Override
-    public LabeledDenseMatrix<String> getUserSimilaritiesByEntity(Interval interval) {
-        return occurrenceStatsDAO.getUserSimilaritiesByValue(interval);
+    public LabeledDenseMatrix<String> getUserSimilaritiesByEntity(Interval interval,
+                                                                  boolean withBots) {
+        return occurrenceStatsDAO.getUserSimilaritiesByValue(interval, withBots);
     }
 
     /**
@@ -109,11 +116,14 @@ public class EntityDAOImpl extends AbstractIdleService implements IEntityDAO {
     @Override
     public Map<String, Double> getActiveUsersByMethod(Interval interval,
                                                       ActiveMethod method,
-                                                      int resultSize) {
+                                                      int resultSize,
+                                                      boolean withBots) {
         if (method == ActiveMethod.ToTV) {
-            return occurrenceStatsDAO.getActiveColumnsByToTV("username", interval, resultSize);
+            return occurrenceStatsDAO.getActiveColumnsByToTV("username", interval, resultSize,
+                                                             withBots);
         } else if (method == ActiveMethod.ToMV) {
-            return occurrenceStatsDAO.getActiveColumnsByToMV("username", interval, resultSize);
+            return occurrenceStatsDAO.getActiveColumnsByToMV("username", interval, resultSize,
+                                                             withBots);
         } else {
             throw new UnsupportedOperationException(String.format("Method %s not supported",
                                                                   method));
@@ -126,11 +136,14 @@ public class EntityDAOImpl extends AbstractIdleService implements IEntityDAO {
     @Override
     public Map<String, Double> getActiveRoomsByMethod(Interval interval,
                                                       ActiveMethod method,
-                                                      int resultSize) {
+                                                      int resultSize,
+                                                      boolean withBots) {
         if (method == ActiveMethod.ToTV) {
-            return occurrenceStatsDAO.getActiveColumnsByToTV("roomName", interval, resultSize);
+            return occurrenceStatsDAO.getActiveColumnsByToTV("roomName", interval, resultSize,
+                                                             withBots);
         } else if (method == ActiveMethod.ToMV) {
-            return occurrenceStatsDAO.getActiveColumnsByToMV("roomName", interval, resultSize);
+            return occurrenceStatsDAO.getActiveColumnsByToMV("roomName", interval, resultSize,
+                                                             withBots);
         } else {
             throw new UnsupportedOperationException(String.format("Method %s not supported",
                                                                   method));

--- a/compute/src/main/java/com/chatalytics/compute/db/dao/IEmojiDAO.java
+++ b/compute/src/main/java/com/chatalytics/compute/db/dao/IEmojiDAO.java
@@ -62,12 +62,15 @@ public interface IEmojiDAO extends Service {
      *            Optionally supply a list of room names. This list can be empty
      * @param usernames
      *            Optionally supply a list of user names. This list can be empty
+     * @param withBots
+     *            Set to true if the result should include mentions by bots
      * @return A list of {@link EmojiEntity} representing all the times emojis were mentioned in the
      *         given time period
      */
      List<EmojiEntity> getAllMentions(Interval interval,
                                       List<String> roomNames,
-                                      List<String> usernames);
+                                      List<String> usernames,
+                                      boolean withBots);
 
     /**
      * Returns the total number of times an emoji was mentioned in the given <code>interval</code>.
@@ -81,12 +84,15 @@ public interface IEmojiDAO extends Service {
      *            Optionally supply a list of room names. This list can be empty
      * @param usernames
      *            Optionally supply a list of user names. This list can be empty
+     * @param withBots
+     *            Set to true if the result should include mentions by bots
      * @return The total number of times the emoji was mentioned in the given time interval
      */
      int getTotalMentionsForEmoji(String emoji,
                                   Interval interval,
                                   List<String> roomNames,
-                                  List<String> usernames);
+                                  List<String> usernames,
+                                  boolean withBots);
 
     /**
      * Returns back the top emojis in the given time interval, and optionally by user name and/or
@@ -100,65 +106,78 @@ public interface IEmojiDAO extends Service {
      *            Optionally supply a list of user names. This list can be empty
      * @param resultSize
      *            The number of top emojis to return back
+     * @param withBots
+     *            Set to true if the result should include mentions by bots
      * @return Returns back a map of emoji to number of occurrences.
      */
      Map<String, Long> getTopEmojis(Interval interval,
                                     List<String> roomNames,
                                     List<String> usernames,
-                                    int resultSize);
-
-     /**
-      * Given a time interval this method will return a labeled room by room matrix with all the
-      * similar rooms, based on the emoji value clustered together. For more information see
-      * {@link GraphPartition#getSimilarityMatrix(LabeledMTJMatrix)}
-      *
-      * @param interval
-      *            The interval to search in
-      * @return A labeled matrix
-      */
-     LabeledDenseMatrix<String> getRoomSimilaritiesByEmoji(Interval interval);
-
-     /**
-      * Given a time interval this method will return a labeled user by user matrix with all the
-      * similar users, based on the emoji value clustered together. For more information see
-      * {@link GraphPartition#getSimilarityMatrix(LabeledMTJMatrix)}
-      *
-      * @param interval
-      *            The interval to search in
-      * @return A labeled matrix
-      */
-     LabeledDenseMatrix<String> getUserSimilaritiesByEmoji(Interval interval);
-
-     /**
-      * Returns a sorted map of users to a ratio, where the ratio is one of {@link ActiveMethod}s
-      *
-      * @param interval
-      *            The interval to get the top values in. Note that the start is inclusive and the
-      *            end is exclusive
-      * @param method
-      *            The method to compute top users for
-      * @param resultSize
-      *            The result size
-      * @return A sorted map of top users to ratio
-      */
-     Map<String, Double> getActiveUsersByMethod(Interval interval,
-                                             ActiveMethod method,
-                                             int resultSize);
+                                    int resultSize,
+                                    boolean withBots);
 
     /**
-      * Returns a sorted map of rooms to a ratio, where the ratio is one of {@link ActiveMethod}s
-      *
-      * @param interval
-      *            The interval to get the top values in. Note that the start is inclusive and the
-      *            end is exclusive
-      * @param method
-      *            The method to compute top users for
-      * @param resultSize
-      *            The result size
-      * @return A sorted map of top room to ratio
-      */
-     Map<String, Double> getActiveRoomsByMethod(Interval interval,
-                                             ActiveMethod method,
-                                             int resultSize);
+     * Given a time interval this method will return a labeled room by room matrix with all the
+     * similar rooms, based on the emoji value clustered together. For more information see
+     * {@link GraphPartition#getSimilarityMatrix(LabeledMTJMatrix)}
+     *
+     * @param interval
+     *            The interval to search in
+     * @param withBots
+     *            Set to true if the result should include mentions by bots
+     * @return A labeled matrix
+     */
+    LabeledDenseMatrix<String> getRoomSimilaritiesByEmoji(Interval interval, boolean withBots);
+
+    /**
+     * Given a time interval this method will return a labeled user by user matrix with all the
+     * similar users, based on the emoji value clustered together. For more information see
+     * {@link GraphPartition#getSimilarityMatrix(LabeledMTJMatrix)}
+     *
+     * @param interval
+     *            The interval to search in
+     * @param withBots
+     *            Set to true if the result should include mentions by bots
+     * @return A labeled matrix
+     */
+    LabeledDenseMatrix<String> getUserSimilaritiesByEmoji(Interval interval, boolean withBots);
+
+    /**
+     * Returns a sorted map of users to a ratio, where the ratio is one of {@link ActiveMethod}s
+     *
+     * @param interval
+     *            The interval to get the top values in. Note that the start is inclusive and the
+     *            end is exclusive
+     * @param method
+     *            The method to compute top users for
+     * @param resultSize
+     *            The result size
+     * @param withBots
+     *            Set to true if the result should include mentions by bots
+     * @return A sorted map of top users to ratio
+     */
+    Map<String, Double> getActiveUsersByMethod(Interval interval,
+                                               ActiveMethod method,
+                                               int resultSize,
+                                               boolean withBots);
+
+    /**
+     * Returns a sorted map of rooms to a ratio, where the ratio is one of {@link ActiveMethod}s
+     *
+     * @param interval
+     *            The interval to get the top values in. Note that the start is inclusive and the
+     *            end is exclusive
+     * @param method
+     *            The method to compute top users for
+     * @param resultSize
+     *            The result size
+     * @param withBots
+     *            Set to true if the result should include mentions by bots
+     * @return A sorted map of top room to ratio
+     */
+    Map<String, Double> getActiveRoomsByMethod(Interval interval,
+                                               ActiveMethod method,
+                                               int resultSize,
+                                               boolean withBots);
 
 }

--- a/compute/src/main/java/com/chatalytics/compute/db/dao/IEntityDAO.java
+++ b/compute/src/main/java/com/chatalytics/compute/db/dao/IEntityDAO.java
@@ -62,12 +62,15 @@ public interface IEntityDAO extends Service {
      *            Optionally supply a list of room names. This list can be empty
      * @param usernames
      *            Optionally supply a list of user names. This list can be empty
+     * @param withBots
+     *            Set to true if the result should include mentions by bots
      * @return A list of {@link ChatEntity} representing all the times this entity was mentioned in
      *         the given time period
      */
     List<ChatEntity> getAllMentions(Interval interval,
                                     List<String> roomNames,
-                                    List<String> usernames);
+                                    List<String> usernames,
+                                    boolean withBots);
 
     /**
      * Returns the total number of times an entity was mentioned in the given <code>interval</code>.
@@ -81,12 +84,15 @@ public interface IEntityDAO extends Service {
      *            Optionally supply a list of room names. This list can be empty
      * @param usernames
      *            Optionally supply a list of user names. This list can be empty
+     * @param withBots
+     *            Set to true if the result should include mentions by bots
      * @return The total number of times the entity was mentioned in the given time interval
      */
      int getTotalMentionsForEntity(String entity,
                                    Interval interval,
                                    List<String> roomNames,
-                                   List<String> usernames);
+                                   List<String> usernames,
+                                   boolean withBots);
 
 
     /**
@@ -101,64 +107,77 @@ public interface IEntityDAO extends Service {
      *            Optionally supply a list of user names. This list can be empty
      * @param resultSize
      *            The number of top entities to return back
+     * @param withBots
+     *            Set to true if the result should include mentions by bots
      * @return Returns back a map of entity value to number of occurrences.
      */
-     Map<String, Long> getTopEntities(Interval interval,
-                                      List<String> roomNames,
-                                      List<String> usernames,
-                                      int resultSize);
-
-     /**
-      * Given a time interval this method will return a labeled room by room matrix with all the
-      * similar rooms, based on the entity value clustered together. For more information see
-      * {@link GraphPartition#getSimilarityMatrix(LabeledMTJMatrix)}
-      *
-      * @param interval
-      *            The interval to search in
-      * @return A labeled matrix
-      */
-     LabeledDenseMatrix<String> getRoomSimilaritiesByEntity(Interval interval);
-
-     /**
-      * Given a time interval this method will return a labeled user by user matrix with all the
-      * similar users, based on the entity value clustered together. For more information see
-      * {@link GraphPartition#getSimilarityMatrix(LabeledMTJMatrix)}
-      *
-      * @param interval
-      *            The interval to search in
-      * @return A labeled matrix
-      */
-     LabeledDenseMatrix<String> getUserSimilaritiesByEntity(Interval interval);
-
-     /**
-      * Returns a sorted map of users to a ratio, where the ratio is one of {@link ActiveMethod}s
-      *
-      * @param interval
-      *            The interval to get the top values in. Note that the start is inclusive and the
-      *            end is exclusive
-      * @param method
-      *            The method to compute top users for
-      * @param resultSize
-      *            The result size
-      * @return A sorted map of top users to ratio
-      */
-     Map<String, Double> getActiveUsersByMethod(Interval interval,
-                                                ActiveMethod method,
-                                                int resultSize);
+    Map<String, Long> getTopEntities(Interval interval,
+                                     List<String> roomNames,
+                                     List<String> usernames,
+                                     int resultSize,
+                                     boolean withBots);
 
     /**
-      * Returns a sorted map of rooms to a ratio, where the ratio is one of {@link ActiveMethod}s
-      *
-      * @param interval
-      *            The interval to get the top values in. Note that the start is inclusive and the
-      *            end is exclusive
-      * @param method
-      *            The method to compute top users for
-      * @param resultSize
-      *            The result size
-      * @return A sorted map of top room to ratio
-      */
-     Map<String, Double> getActiveRoomsByMethod(Interval interval,
-                                                ActiveMethod method,
-                                                int resultSize);
+     * Given a time interval this method will return a labeled room by room matrix with all the
+     * similar rooms, based on the entity value clustered together. For more information see
+     * {@link GraphPartition#getSimilarityMatrix(LabeledMTJMatrix)}
+     *
+     * @param interval
+     *            The interval to search in
+     * @param withBots
+     *            Set to true if the result should include mentions by bots
+     * @return A labeled matrix
+     */
+    LabeledDenseMatrix<String> getRoomSimilaritiesByEntity(Interval interval, boolean withBots);
+
+    /**
+     * Given a time interval this method will return a labeled user by user matrix with all the
+     * similar users, based on the entity value clustered together. For more information see
+     * {@link GraphPartition#getSimilarityMatrix(LabeledMTJMatrix)}
+     *
+     * @param interval
+     *            The interval to search in
+     * @param withBots
+     *            Set to true if the result should include mentions by bots
+     * @return A labeled matrix
+     */
+    LabeledDenseMatrix<String> getUserSimilaritiesByEntity(Interval interval, boolean withBots);
+
+    /**
+     * Returns a sorted map of users to a ratio, where the ratio is one of {@link ActiveMethod}s
+     *
+     * @param interval
+     *            The interval to get the top values in. Note that the start is inclusive and the
+     *            end is exclusive
+     * @param method
+     *            The method to compute top users for
+     * @param resultSize
+     *            The result size
+     * @param withBots
+     *            Set to true if the result should include mentions by bots
+     * @return A sorted map of top users to ratio
+     */
+    Map<String, Double> getActiveUsersByMethod(Interval interval,
+                                               ActiveMethod method,
+                                               int resultSize,
+                                               boolean withBots);
+
+    /**
+     * Returns a sorted map of rooms to a ratio, where the ratio is one of {@link ActiveMethod}s
+     *
+     * @param interval
+     *            The interval to get the top values in. Note that the start is inclusive and the
+     *            end is exclusive
+     * @param method
+     *            The method to compute top users for
+     * @param resultSize
+     *            The result size
+     * @param withBots
+     *            Set to true if the result should include mentions by bots
+     * @return A sorted map of top room to ratio
+     */
+    Map<String, Double> getActiveRoomsByMethod(Interval interval,
+                                               ActiveMethod method,
+                                               int resultSize,
+                                               boolean withBots);
 }

--- a/compute/src/main/java/com/chatalytics/compute/db/dao/IMentionableDAO.java
+++ b/compute/src/main/java/com/chatalytics/compute/db/dao/IMentionableDAO.java
@@ -75,10 +75,13 @@ public interface IMentionableDAO<K extends Serializable, T extends IMentionable<
      *            Optionally supply a list of room names. This list can be empty
      * @param usernames
      *            Optionally supply a list of user names. This list can be empty
+     * @param withBots
+     *            Set to true if the result should include mentions by bots
      * @return A list of <code>T</code> representing all the times this value was mentioned
      *         in the given time period
      */
-    List<T> getAllMentions(Interval interval, List<String> roomNames, List<String> usernames);
+    List<T> getAllMentions(Interval interval, List<String> roomNames, List<String> usernames,
+                           boolean withBots);
 
     /**
      * Returns the total number of times a type <code>T</code> was mentioned in the given
@@ -93,12 +96,15 @@ public interface IMentionableDAO<K extends Serializable, T extends IMentionable<
      *            Optionally supply a list of room names. This list can be empty
      * @param usernames
      *            Optionally supply a list of user names. This list can be empty
+     * @param withBots
+     *            Set to true if the result should include mentions by bots
      * @return The total number of times the value was mentioned in the given time interval
      */
     int getTotalMentionsForType(K value,
                                 Interval interval,
                                 List<String> roomNames,
-                                List<String> usernames);
+                                List<String> usernames,
+                                boolean withBots);
 
     /**
      * Returns the total number of mentions of a particular type this DAO represents
@@ -109,11 +115,14 @@ public interface IMentionableDAO<K extends Serializable, T extends IMentionable<
      *            Optionally supply a list of room names. This list can be empty
      * @param usernames
      *            Optionally supply a list of user names. This list can be empty
+     * @param withBots
+     *            Set to true if the result should include mentions by bots
      * @return The total number of mentions based on the given parameters
      */
     int getTotalMentionsOfType(Interval interval,
                                List<String> roomNames,
-                               List<String> usernames);
+                               List<String> usernames,
+                               boolean withBots);
 
     /**
      * Returns back the top mentioned values of a type in the given time <code>interval</code>, and
@@ -127,12 +136,15 @@ public interface IMentionableDAO<K extends Serializable, T extends IMentionable<
      *            Optionally supply a list of user names. This list can be empty
      * @param resultSize
      *            The number of top entities to return back
+     * @param withBots
+     *            Set to true if the result should include mentions by bots
      * @return Returns back a map of the value of a type to number of occurrences.
      */
     Map<K, Long> getTopValuesOfType(Interval interval,
                                     List<String> roomName,
                                     List<String> username,
-                                    int resultSize);
+                                    int resultSize,
+                                    boolean withBots);
 
     /**
      * Returns a sorted map of type to a ratio, where the ratio is the type volume over the total
@@ -145,9 +157,12 @@ public interface IMentionableDAO<K extends Serializable, T extends IMentionable<
      *            end is exclusive
      * @param resultSize
      *            The result size
+     * @param withBots
+     *            Set to true if the result should include mentions by bots
      * @return A sorted map of top column to ratio
      */
-    Map<String, Double> getActiveColumnsByToTV(String columnName, Interval interval, int resultSize);
+    Map<String, Double> getActiveColumnsByToTV(String columnName, Interval interval, int resultSize,
+                                               boolean withBots);
 
     /**
      * Returns a sorted map of type to a ratio, where the ratio is the type volume over the total
@@ -160,9 +175,12 @@ public interface IMentionableDAO<K extends Serializable, T extends IMentionable<
      *            end is exclusive
      * @param resultSize
      *            The result size
+     * @param withBots
+     *            Set to true if the result should include mentions by bots
      * @return A sorted map of top column to ratio
      */
-    Map<String, Double> getActiveColumnsByToMV(String columnName, Interval interval, int resultSize);
+    Map<String, Double> getActiveColumnsByToMV(String columnName, Interval interval, int resultSize,
+                                               boolean withBots);
 
     /**
      * Given a time interval this method will return a labeled room by room matrix with all the
@@ -171,9 +189,11 @@ public interface IMentionableDAO<K extends Serializable, T extends IMentionable<
      *
      * @param interval
      *            The interval to search in
+     * @param withBots
+     *            Set to true if the result should include mentions by bots
      * @return A labeled matrix
      */
-    LabeledDenseMatrix<String> getRoomSimilaritiesByValue(Interval interval);
+    LabeledDenseMatrix<String> getRoomSimilaritiesByValue(Interval interval, boolean withBots);
 
     /**
      * Given a time interval this method will return a labeled user by user matrix with all the
@@ -182,9 +202,11 @@ public interface IMentionableDAO<K extends Serializable, T extends IMentionable<
      *
      * @param interval
      *            The interval to search in
+     * @param withBots
+     *            Set to true if the result should include mentions by bots
      * @return A labeled matrix
      */
-    LabeledDenseMatrix<String> getUserSimilaritiesByValue(Interval interval);
+    LabeledDenseMatrix<String> getUserSimilaritiesByValue(Interval interval, boolean withBots);
 
     /**
      * Gets the type this DAO is working with

--- a/compute/src/main/java/com/chatalytics/compute/db/dao/IMessageSummaryDAO.java
+++ b/compute/src/main/java/com/chatalytics/compute/db/dao/IMessageSummaryDAO.java
@@ -51,22 +51,25 @@ public interface IMessageSummaryDAO extends Service {
                                                         List<String> roomNames,
                                                         List<String> usernames);
 
-     /**
-      * Returns all the mention occurrences for an entity inside the given <code>interval</code>.
-      *
-      * @param interval
-      *            The interval of interest. Note that the query is inclusive of the start time and
-      *            exclusive of the end time.
-      * @param roomNames
+    /**
+     * Returns all the mention occurrences for an entity inside the given <code>interval</code>.
+     *
+     * @param interval
+     *            The interval of interest. Note that the query is inclusive of the start time and
+     *            exclusive of the end time.
+     * @param roomNames
      *            Optionally supply a list of room names. This list can be empty
-      * @param usernames
+     * @param usernames
      *            Optionally supply a list of user names. This list can be empty
-      * @return A list of {@link ChatEntity} representing all the times this entity was mentioned
-      *         in the given time period
-      */
-      List<MessageSummary> getAllMessageSummaries(Interval interval,
-                                                  List<String> roomNames,
-                                                  List<String> usernames);
+     * @param withBots
+     *            Set to true if the result should include mentions by bots
+     * @return A list of {@link ChatEntity} representing all the times this entity was mentioned
+     *         in the given time period
+     */
+    List<MessageSummary> getAllMessageSummaries(Interval interval,
+                                                List<String> roomNames,
+                                                List<String> usernames,
+                                                boolean withBots);
 
     /**
      * Gets the total number of message summaries in the given time period with username and room
@@ -78,11 +81,14 @@ public interface IMessageSummaryDAO extends Service {
      *            Optionally supply a list of room names. This list can be empty
      * @param usernames
      *            Optionally supply a list of user names. This list can be empty
+     * @param withBots
+     *            Set to true if the result should include mentions by bots
      * @return The total count
      */
     int getTotalMessageSummaries(Interval interval,
                                  List<String> roomNames,
-                                 List<String> usernames);
+                                 List<String> usernames,
+                                 boolean withBots);
 
     /**
      * Gets the total number of message summaries for a given type in the given time period with
@@ -96,12 +102,15 @@ public interface IMessageSummaryDAO extends Service {
      *            Optionally supply a list of room names. This list can be empty
      * @param usernames
      *            Optionally supply a list of user names. This list can be empty
+     * @param withBots
+     *            Set to true if the result should include mentions by bots
      * @return The total count
      */
     int getTotalMessageSummariesForType(MessageType type,
                                         Interval interval,
                                         List<String> roomNames,
-                                        List<String> usernames);
+                                        List<String> usernames,
+                                        boolean withBots);
 
     /**
      * Returns a sorted map of users to a ratio, where the ratio is one of {@link ActiveMethod}s
@@ -113,11 +122,14 @@ public interface IMessageSummaryDAO extends Service {
      *            The method to compute top users for
      * @param resultSize
      *            The result size
+     * @param withBots
+     *            Set to true if the result should include mentions by bots
      * @return A sorted map of top users to ratio
      */
     Map<String, Double> getActiveUsersByMethod(Interval interval,
                                                ActiveMethod method,
-                                               int resultSize);
+                                               int resultSize,
+                                               boolean withBots);
 
    /**
      * Returns a sorted map of rooms to a ratio, where the ratio is one of {@link ActiveMethod}s
@@ -129,9 +141,12 @@ public interface IMessageSummaryDAO extends Service {
      *            The method to compute top users for
      * @param resultSize
      *            The result size
+     * @param withBots
+     *            Set to true if the result should include mentions by bots
      * @return A sorted map of top room to ratio
      */
     Map<String, Double> getActiveRoomsByMethod(Interval interval,
                                                ActiveMethod method,
-                                               int resultSize);
+                                               int resultSize,
+                                               boolean withBots);
 }

--- a/compute/src/main/java/com/chatalytics/compute/db/dao/MessageSummaryDAOImpl.java
+++ b/compute/src/main/java/com/chatalytics/compute/db/dao/MessageSummaryDAOImpl.java
@@ -56,8 +56,9 @@ public class MessageSummaryDAOImpl extends AbstractIdleService implements IMessa
     @Override
     public List<MessageSummary> getAllMessageSummaries(Interval interval,
                                                        List<String> roomNames,
-                                                       List<String> usernames) {
-        return occurrenceStatsDAO.getAllMentions(interval, roomNames, usernames);
+                                                       List<String> usernames,
+                                                       boolean withBots) {
+        return occurrenceStatsDAO.getAllMentions(interval, roomNames, usernames, withBots);
     }
 
     /**
@@ -65,8 +66,8 @@ public class MessageSummaryDAOImpl extends AbstractIdleService implements IMessa
      */
     @Override
     public int getTotalMessageSummaries(Interval interval, List<String> roomNames,
-                                        List<String> usernames) {
-        return occurrenceStatsDAO.getTotalMentionsOfType(interval, roomNames, usernames);
+                                        List<String> usernames, boolean withBots) {
+        return occurrenceStatsDAO.getTotalMentionsOfType(interval, roomNames, usernames, withBots);
     }
 
     /**
@@ -76,18 +77,23 @@ public class MessageSummaryDAOImpl extends AbstractIdleService implements IMessa
     public int getTotalMessageSummariesForType(MessageType type,
                                                Interval interval,
                                                List<String> roomNames,
-                                               List<String> usernames) {
-        return occurrenceStatsDAO.getTotalMentionsForType(type, interval, roomNames, usernames);
+                                               List<String> usernames,
+                                               boolean withBots) {
+        return occurrenceStatsDAO.getTotalMentionsForType(type, interval, roomNames, usernames,
+                                                          withBots);
     }
 
     @Override
     public Map<String, Double> getActiveUsersByMethod(Interval interval,
                                                       ActiveMethod method,
-                                                      int resultSize) {
+                                                      int resultSize,
+                                                      boolean withBots) {
         if (method == ActiveMethod.ToTV) {
-            return occurrenceStatsDAO.getActiveColumnsByToTV("username", interval, resultSize);
+            return occurrenceStatsDAO.getActiveColumnsByToTV("username", interval, resultSize,
+                                                             withBots);
         } else if (method == ActiveMethod.ToMV) {
-            return occurrenceStatsDAO.getActiveColumnsByToMV("username", interval, resultSize);
+            return occurrenceStatsDAO.getActiveColumnsByToMV("username", interval, resultSize,
+                                                             withBots);
         } else {
             throw new UnsupportedOperationException(String.format("Method %s not supported",
                                                                   method));
@@ -97,11 +103,14 @@ public class MessageSummaryDAOImpl extends AbstractIdleService implements IMessa
     @Override
     public Map<String, Double> getActiveRoomsByMethod(Interval interval,
                                                       ActiveMethod method,
-                                                      int resultSize) {
+                                                      int resultSize,
+                                                      boolean withBots) {
         if (method == ActiveMethod.ToTV) {
-            return occurrenceStatsDAO.getActiveColumnsByToTV("roomName", interval, resultSize);
+            return occurrenceStatsDAO.getActiveColumnsByToTV("roomName", interval, resultSize,
+                                                             withBots);
         } else if (method == ActiveMethod.ToMV) {
-            return occurrenceStatsDAO.getActiveColumnsByToMV("roomName", interval, resultSize);
+            return occurrenceStatsDAO.getActiveColumnsByToMV("roomName", interval, resultSize,
+                                                             withBots);
         } else {
             throw new UnsupportedOperationException(String.format("Method %s not supported",
                                                                   method));

--- a/compute/src/test/java/com/chatalytics/compute/db/dao/EmojiDAOImplTest.java
+++ b/compute/src/test/java/com/chatalytics/compute/db/dao/EmojiDAOImplTest.java
@@ -84,20 +84,26 @@ public class EmojiDAOImplTest {
         assertEquals(0, underTest.getTotalMentionsForEmoji("unknownemoji",
                                                            timeInterval,
                                                            ImmutableList.of(),
-                                                           ImmutableList.of()));
+                                                           ImmutableList.of(),
+                                                           true));
 
         // make sure that the sums are correct for a bunch of different queries
         int result = underTest.getTotalMentionsForEmoji("e1", timeInterval,
-                                                        ImmutableList.of(), ImmutableList.of());
+                                                        ImmutableList.of(),
+                                                        ImmutableList.of(),
+                                                        true);
         assertEquals(3, result);
 
         result = underTest.getTotalMentionsForEmoji("e1", timeInterval,
-                                                    ImmutableList.of("room1"), ImmutableList.of());
+                                                    ImmutableList.of("room1"),
+                                                    ImmutableList.of(),
+                                                    true);
         assertEquals(2, result);
 
         result = underTest.getTotalMentionsForEmoji("e1", timeInterval,
                                                     ImmutableList.of("room1"),
-                                                    ImmutableList.of("giannis"));
+                                                    ImmutableList.of("giannis"),
+                                                    true);
         assertEquals(1, result);
     }
 
@@ -127,36 +133,45 @@ public class EmojiDAOImplTest {
     @Test
     public void testGetAllMentions() {
         Interval timeInterval = new Interval(mentionDate, mentionDate.plusHours(3));
-        List<EmojiEntity> result = underTest.getAllMentions(timeInterval, ImmutableList.of(),
-                                                            ImmutableList.of());
+        List<EmojiEntity> result = underTest.getAllMentions(timeInterval,
+                                                            ImmutableList.of(),
+                                                            ImmutableList.of(),
+                                                            true);
         assertEquals(4, result.size());
 
-        result = underTest.getAllMentions(timeInterval, ImmutableList.of("room1"),
-                                          ImmutableList.of());
+        result = underTest.getAllMentions(timeInterval,
+                                          ImmutableList.of("room1"),
+                                          ImmutableList.of(),
+                                          true);
         assertEquals(3, result.size());
 
-        result = underTest.getAllMentions(timeInterval, ImmutableList.of("room1"),
-                                          ImmutableList.of("giannis"));
+        result = underTest.getAllMentions(timeInterval,
+                                          ImmutableList.of("room1"),
+                                          ImmutableList.of("giannis"),
+                                          true);
         assertEquals(2, result.size());
     }
 
     @Test
     public void testGetTopEmojis() {
         Interval timeInterval = new Interval(mentionDate, mentionDate.plusHours(3));
-        Map<String, Long> result = underTest.getTopEmojis(timeInterval, ImmutableList.of(),
-                                                          ImmutableList.of(), 10);
+        Map<String, Long> result = underTest.getTopEmojis(timeInterval,
+                                                          ImmutableList.of(),
+                                                          ImmutableList.of(),
+                                                          10,
+                                                          true);
         assertEquals(2, result.size());
         assertEquals(3L, result.get("e1").longValue());
         assertEquals(1L, result.get("e2").longValue());
 
         result = underTest.getTopEmojis(timeInterval, ImmutableList.of("room1"), ImmutableList.of(),
-                                        10);
+                                        10, true);
         assertEquals(2, result.size());
         assertEquals(2L, result.get("e1").longValue());
         assertEquals(1L, result.get("e2").longValue());
 
         result = underTest.getTopEmojis(timeInterval, ImmutableList.of("room1"),
-                                        ImmutableList.of("giannis"), 10);
+                                        ImmutableList.of("giannis"), 10, true);
         assertEquals(2, result.size());
         assertEquals(1L, result.get("e1").longValue());
         assertEquals(1L, result.get("e2").longValue());
@@ -165,7 +180,8 @@ public class EmojiDAOImplTest {
     @Test
     public void testGetRoomSimilaritiesByEmoji() {
         Interval timeInterval = new Interval(mentionDate, mentionDate.plusHours(3));
-        LabeledDenseMatrix<String> result = underTest.getRoomSimilaritiesByEmoji(timeInterval);
+        LabeledDenseMatrix<String> result = underTest.getRoomSimilaritiesByEmoji(timeInterval,
+                                                                                 true);
         assertEquals(2, result.getLabels().size());
         assertEquals(2, result.getMatrix().length);
     }
@@ -173,7 +189,8 @@ public class EmojiDAOImplTest {
     @Test
     public void testGetUserSimilaritiesByEmoji() {
         Interval timeInterval = new Interval(mentionDate, mentionDate.plusHours(3));
-        LabeledDenseMatrix<String> result = underTest.getUserSimilaritiesByEmoji(timeInterval);
+        LabeledDenseMatrix<String> result = underTest.getUserSimilaritiesByEmoji(timeInterval,
+                                                                                 true);
         assertEquals(2, result.getLabels().size());
         assertEquals(2, result.getMatrix().length);
     }
@@ -183,12 +200,12 @@ public class EmojiDAOImplTest {
         Interval interval = new Interval(mentionDate.minusMillis(1), mentionDate.plusMillis(1));
 
         Map<String, Double> result = underTest.getActiveRoomsByMethod(interval, ActiveMethod.ToTV,
-                                                                      10);
+                                                                      10, true);
         assertEquals(2, result.size());
         assertEquals(0.75, result.get("room1"), 0);
         assertEquals(0.25, result.get("room2"), 0);
 
-        result = underTest.getActiveRoomsByMethod(interval, ActiveMethod.ToMV, 10);
+        result = underTest.getActiveRoomsByMethod(interval, ActiveMethod.ToMV, 10, true);
         assertEquals(2, result.size());
         assertEquals(0.15, result.get("room1"), 0);
         assertEquals(0.05, result.get("room2"), 0);
@@ -199,12 +216,12 @@ public class EmojiDAOImplTest {
         Interval interval = new Interval(mentionDate.minusMillis(1), mentionDate.plusMillis(1));
 
         Map<String, Double> result =
-                underTest.getActiveUsersByMethod(interval, ActiveMethod.ToTV, 10);
+                underTest.getActiveUsersByMethod(interval, ActiveMethod.ToTV, 10, true);
         assertEquals(2, result.size());
         assertEquals(0.75, result.get("giannis"), 0);
         assertEquals(0.25, result.get("jane"), 0);
 
-        result = underTest.getActiveUsersByMethod(interval, ActiveMethod.ToMV, 10);
+        result = underTest.getActiveUsersByMethod(interval, ActiveMethod.ToMV, 10, true);
         assertEquals(2, result.size());
         assertEquals(0.15, result.get("giannis"), 0);
         assertEquals(0.05, result.get("jane"), 0);

--- a/compute/src/test/java/com/chatalytics/compute/db/dao/EntityDAOImplTest.java
+++ b/compute/src/test/java/com/chatalytics/compute/db/dao/EntityDAOImplTest.java
@@ -85,20 +85,26 @@ public class EntityDAOImplTest {
         assertEquals(0, underTest.getTotalMentionsForEntity("unknownentity",
                                                             timeInterval,
                                                             ImmutableList.of(),
-                                                            ImmutableList.of()));
+                                                            ImmutableList.of(),
+                                                            true));
 
         // make sure that the sums are correct for a bunch of different queries
         int result = underTest.getTotalMentionsForEntity("e1", timeInterval,
-                                                          ImmutableList.of(), ImmutableList.of());
+                                                          ImmutableList.of(),
+                                                          ImmutableList.of(),
+                                                          true);
         assertEquals(3, result);
 
         result = underTest.getTotalMentionsForEntity("e1", timeInterval,
-                                                     ImmutableList.of("room1"), ImmutableList.of());
+                                                     ImmutableList.of("room1"),
+                                                     ImmutableList.of(),
+                                                     true);
         assertEquals(2, result);
 
         result = underTest.getTotalMentionsForEntity("e1", timeInterval,
                                                      ImmutableList.of("room1"),
-                                                     ImmutableList.of("giannis"));
+                                                     ImmutableList.of("giannis"),
+                                                     true);
         assertEquals(1, result);
     }
 
@@ -129,16 +135,22 @@ public class EntityDAOImplTest {
     @Test
     public void testGetAllMentions() {
         Interval timeInterval = new Interval(mentionDate, mentionDate.plusHours(3));
-        List<ChatEntity> result = underTest.getAllMentions(timeInterval, ImmutableList.of(),
-                                                           ImmutableList.of());
+        List<ChatEntity> result = underTest.getAllMentions(timeInterval,
+                                                           ImmutableList.of(),
+                                                           ImmutableList.of(),
+                                                           true);
         assertEquals(4, result.size());
 
-        result = underTest.getAllMentions(timeInterval, ImmutableList.of("room1"),
-                                          ImmutableList.of());
+        result = underTest.getAllMentions(timeInterval,
+                                          ImmutableList.of("room1"),
+                                          ImmutableList.of(),
+                                          true);
         assertEquals(3, result.size());
 
-        result = underTest.getAllMentions(timeInterval, ImmutableList.of("room1"),
-                                          ImmutableList.of("giannis"));
+        result = underTest.getAllMentions(timeInterval,
+                                          ImmutableList.of("room1"),
+                                          ImmutableList.of("giannis"),
+                                          true);
         assertEquals(2, result.size());
     }
 
@@ -146,19 +158,20 @@ public class EntityDAOImplTest {
     public void testGetTopEntities() {
         Interval timeInterval = new Interval(mentionDate, mentionDate.plusHours(3));
         Map<String, Long> result =
-            underTest.getTopEntities(timeInterval, ImmutableList.of(), ImmutableList.of(), 10);
+            underTest.getTopEntities(timeInterval, ImmutableList.of(), ImmutableList.of(), 10,
+                                     true);
         assertEquals(2, result.size());
         assertEquals(3L, result.get("e1").longValue());
         assertEquals(1L, result.get("e2").longValue());
 
         result = underTest.getTopEntities(timeInterval, ImmutableList.of("room1"),
-                                          ImmutableList.of(), 10);
+                                          ImmutableList.of(), 10, true);
         assertEquals(2, result.size());
         assertEquals(2L, result.get("e1").longValue());
         assertEquals(1L, result.get("e2").longValue());
 
         result = underTest.getTopEntities(timeInterval, ImmutableList.of("room1"),
-                                          ImmutableList.of("giannis"), 10);
+                                          ImmutableList.of("giannis"), 10, true);
         assertEquals(2, result.size());
         assertEquals(1L, result.get("e1").longValue());
         assertEquals(1L, result.get("e2").longValue());
@@ -167,7 +180,8 @@ public class EntityDAOImplTest {
     @Test
     public void testGetRoomSimilaritiesByEntity() {
         Interval timeInterval = new Interval(mentionDate, mentionDate.plusHours(3));
-        LabeledDenseMatrix<String> result = underTest.getRoomSimilaritiesByEntity(timeInterval);
+        LabeledDenseMatrix<String> result = underTest.getRoomSimilaritiesByEntity(timeInterval,
+                                                                                  true);
         assertEquals(2, result.getLabels().size());
         assertEquals(2, result.getMatrix().length);
     }
@@ -175,7 +189,8 @@ public class EntityDAOImplTest {
     @Test
     public void testGetUserSimilaritiesByEntity() {
         Interval timeInterval = new Interval(mentionDate, mentionDate.plusHours(3));
-        LabeledDenseMatrix<String> result = underTest.getUserSimilaritiesByEntity(timeInterval);
+        LabeledDenseMatrix<String> result = underTest.getUserSimilaritiesByEntity(timeInterval,
+                                                                                  true);
         assertEquals(2, result.getLabels().size());
         assertEquals(2, result.getMatrix().length);
     }
@@ -185,12 +200,12 @@ public class EntityDAOImplTest {
         Interval interval = new Interval(mentionDate.minusMillis(1), mentionDate.plusMillis(1));
 
         Map<String, Double> result =
-                underTest.getActiveRoomsByMethod(interval, ActiveMethod.ToTV, 10);
+                underTest.getActiveRoomsByMethod(interval, ActiveMethod.ToTV, 10, true);
         assertEquals(2, result.size());
         assertEquals(0.75, result.get("room1"), 0);
         assertEquals(0.25, result.get("room2"), 0);
 
-        result = underTest.getActiveRoomsByMethod(interval, ActiveMethod.ToMV, 10);
+        result = underTest.getActiveRoomsByMethod(interval, ActiveMethod.ToMV, 10, true);
         assertEquals(2, result.size());
         assertEquals(0.15, result.get("room1"), 0);
         assertEquals(0.05, result.get("room2"), 0);
@@ -201,12 +216,12 @@ public class EntityDAOImplTest {
         Interval interval = new Interval(mentionDate.minusMillis(1), mentionDate.plusMillis(1));
 
         Map<String, Double> result =
-                underTest.getActiveUsersByMethod(interval, ActiveMethod.ToTV, 10);
+                underTest.getActiveUsersByMethod(interval, ActiveMethod.ToTV, 10, true);
         assertEquals(2, result.size());
         assertEquals(0.75, result.get("giannis"), 0);
         assertEquals(0.25, result.get("jane"), 0);
 
-        result = underTest.getActiveUsersByMethod(interval, ActiveMethod.ToMV, 10);
+        result = underTest.getActiveUsersByMethod(interval, ActiveMethod.ToMV, 10, true);
         assertEquals(2, result.size());
         assertEquals(0.15, result.get("giannis"), 0);
         assertEquals(0.05, result.get("jane"), 0);

--- a/compute/src/test/java/com/chatalytics/compute/db/dao/MentionableDAOTest.java
+++ b/compute/src/test/java/com/chatalytics/compute/db/dao/MentionableDAOTest.java
@@ -54,16 +54,16 @@ public class MentionableDAOTest {
         DateTime end = DateTime.now();
         DateTime start = end.minusDays(1);
 
-        // make r1, r2 and r3 kind of similar and r4
-        underTest.persistValue(new EmojiEntity("u1", "r1", start, "a", 1, false));
+        // make r1, r2 and r3 kind of similar and r4. Also make all of r1 bot mentions
+        underTest.persistValue(new EmojiEntity("u1", "r1", start, "a", 1, true));
         underTest.persistValue(new EmojiEntity("u1", "r2", start.plusMillis(1), "a", 1, false));
 
         underTest.persistValue(new EmojiEntity("u1", "r3", start.plusMillis(2), "a", 1, false));
         underTest.persistValue(new EmojiEntity("u1", "r2", start.plusMillis(3), "b", 1, false));
         underTest.persistValue(new EmojiEntity("u1", "r3", start.plusMillis(4), "b", 1, false));
-        underTest.persistValue(new EmojiEntity("u1", "r1", start.plusMillis(5), "c", 1, false));
+        underTest.persistValue(new EmojiEntity("u1", "r1", start.plusMillis(5), "c", 1, true));
         underTest.persistValue(new EmojiEntity("u1", "r2", start.plusMillis(6), "c", 1, false));
-        underTest.persistValue(new EmojiEntity("u1", "r1", start.plusMillis(7), "d", 1, false));
+        underTest.persistValue(new EmojiEntity("u1", "r1", start.plusMillis(7), "d", 1, true));
         underTest.persistValue(new EmojiEntity("u1", "r2", start.plusMillis(8), "d", 1, false));
         underTest.persistValue(new EmojiEntity("u1", "r3", start.plusMillis(9), "d", 1, false));
 
@@ -75,9 +75,13 @@ public class MentionableDAOTest {
         underTest.persistValue(new EmojiEntity("u1", "r7", start.plusMillis(15), "h", 1, false));
 
         Interval interval = new Interval(start, end);
-        LabeledDenseMatrix<String> result = underTest.getRoomSimilaritiesByValue(interval);
+        LabeledDenseMatrix<String> result = underTest.getRoomSimilaritiesByValue(interval, true);
         assertEquals(7, result.getMatrix().length);
         assertEquals(7, result.getLabels().size());
+
+        result = underTest.getRoomSimilaritiesByValue(interval, false);
+        assertEquals(6, result.getMatrix().length);
+        assertEquals(6, result.getLabels().size());
     }
 
     @Test
@@ -106,7 +110,7 @@ public class MentionableDAOTest {
         DateTime end = DateTime.now();
         DateTime start = end.minusDays(1);
         Interval interval = new Interval(start, end);
-        underTest.persistValue(new EmojiEntity("u1", "r1", start, "a", 1, false));
+        underTest.persistValue(new EmojiEntity("u1", "r1", start, "a", 1, true));
         underTest.persistValue(new EmojiEntity("u1", "r2", start.plusMillis(1), "a", 1, false));
         underTest.persistValue(new EmojiEntity("u2", "r1", start.plusMillis(2), "a", 1, false));
         underTest.persistValue(new EmojiEntity("u1", "r2", start.plusMillis(3), "b", 1, false));
@@ -114,32 +118,35 @@ public class MentionableDAOTest {
         underTest.persistValue(new EmojiEntity("u1", "r3", start.plusMillis(5), "c", 1, false));
 
         int result = underTest.getTotalMentionsOfType(interval, ImmutableList.of(),
-                                                      ImmutableList.of());
+                                                      ImmutableList.of(), true);
         assertEquals(6, result);
 
         result = underTest.getTotalMentionsOfType(interval, ImmutableList.of("r1"),
-                                                  ImmutableList.of());
+                                                  ImmutableList.of(), true);
         assertEquals(2, result);
         result = underTest.getTotalMentionsOfType(interval, ImmutableList.of("r1", "r2"),
-                                                  ImmutableList.of());
+                                                  ImmutableList.of(), true);
         assertEquals(4, result);
 
         result = underTest.getTotalMentionsOfType(interval, ImmutableList.of(),
-                                                  ImmutableList.of("u1"));
+                                                  ImmutableList.of("u1"), true);
         assertEquals(4, result);
         result = underTest.getTotalMentionsOfType(interval, ImmutableList.of(),
-                                                  ImmutableList.of("u1", "u2"));
+                                                  ImmutableList.of("u1", "u2"), true);
         assertEquals(6, result);
 
         result = underTest.getTotalMentionsOfType(interval, ImmutableList.of("r1"),
-                                                  ImmutableList.of("u1"));
+                                                  ImmutableList.of("u1"), true);
         assertEquals(1, result);
         result = underTest.getTotalMentionsOfType(interval, ImmutableList.of("r1", "r2"),
-                                                  ImmutableList.of("u1"));
+                                                  ImmutableList.of("u1"), true);
         result = underTest.getTotalMentionsOfType(interval, ImmutableList.of("r1", "r2"),
-                                                  ImmutableList.of("u1", "u2"));
-
+                                                  ImmutableList.of("u1", "u2"), true);
         assertEquals(4, result);
+
+        result = underTest.getTotalMentionsOfType(interval, ImmutableList.of(),
+                                                  ImmutableList.of(), false);
+        assertEquals(5, result);
     }
 
     @Test
@@ -147,30 +154,33 @@ public class MentionableDAOTest {
         DateTime end = DateTime.now();
         DateTime start = end.minusDays(1);
         Interval interval = new Interval(start, end);
-        underTest.persistValue(new EmojiEntity("u1", "r1", start, "a", 1, false));
+        underTest.persistValue(new EmojiEntity("u1", "r1", start, "a", 1, true));
         underTest.persistValue(new EmojiEntity("u1", "r2", start.plusMillis(1), "a", 1, false));
         underTest.persistValue(new EmojiEntity("u2", "r3", start.plusMillis(2), "a", 1, false));
         underTest.persistValue(new EmojiEntity("u1", "r2", start.plusMillis(3), "b", 1, false));
         underTest.persistValue(new EmojiEntity("u1", "r3", start.plusMillis(5), "c", 1, false));
 
         int result = underTest.getTotalMentionsForType("a", interval, ImmutableList.of(),
-                                                       ImmutableList.of());
+                                                       ImmutableList.of(), true);
         assertEquals(3, result);
 
         result = underTest.getTotalMentionsForType("a", interval, ImmutableList.of("r1"),
-                                                   ImmutableList.of());
+                                                   ImmutableList.of(), true);
         assertEquals(1, result);
         result = underTest.getTotalMentionsForType("a", interval, ImmutableList.of("r1", "r2"),
-                                                   ImmutableList.of());
+                                                   ImmutableList.of(), true);
         assertEquals(2, result);
 
         result = underTest.getTotalMentionsForType("a", interval, ImmutableList.of(),
-                                                   ImmutableList.of("u1"));
+                                                   ImmutableList.of("u1"), true);
         assertEquals(2, result);
         result = underTest.getTotalMentionsForType("a", interval, ImmutableList.of(),
-                                                   ImmutableList.of("u1", "u2"));
+                                                   ImmutableList.of("u1", "u2"), true);
         assertEquals(3, result);
 
+        result = underTest.getTotalMentionsForType("a", interval, ImmutableList.of(),
+                                                   ImmutableList.of(), false);
+        assertEquals(2, result);
     }
 
     @Test
@@ -178,7 +188,7 @@ public class MentionableDAOTest {
         DateTime end = DateTime.now();
         DateTime start = end.minusDays(1);
 
-        underTest.persistValue(new EmojiEntity("u1", "r1", start.plusMillis(1), "a", 1, false));
+        underTest.persistValue(new EmojiEntity("u1", "r1", start.plusMillis(1), "a", 1, true));
         underTest.persistValue(new EmojiEntity("u1", "r2", start.plusMillis(2), "b", 1, false));
         underTest.persistValue(new EmojiEntity("u2", "r3", start.plusMillis(3), "c", 1, false));
         underTest.persistValue(new EmojiEntity("u1", "r4", start.plusMillis(4), "d", 1, false));
@@ -189,7 +199,8 @@ public class MentionableDAOTest {
 
         Interval interval = new Interval(start, end);
 
-        Map<String, Double> result = underTest.getActiveColumnsByToTV("roomName", interval, 100);
+        Map<String, Double> result = underTest.getActiveColumnsByToTV("roomName", interval, 100,
+                                                                      true);
         assertEquals(5, result.size());
         assertEquals(0.375, result.get("r5").doubleValue(), 0);
         assertEquals(0.25, result.get("r4").doubleValue(), 0);
@@ -203,9 +214,17 @@ public class MentionableDAOTest {
             assertTrue(Double.compare(value, previousValue) > 0);
         }
 
+        // exclude bots
+        result = underTest.getActiveColumnsByToTV("roomName", interval, 100, false);
+        assertEquals(4, result.size());
+        assertEquals(0.428, result.get("r5").doubleValue(), 0.001);
+        assertEquals(0.285, result.get("r4").doubleValue(), 0.001);
+        assertEquals(0.142, result.get("r3").doubleValue(), 0.001);
+        assertEquals(0.142, result.get("r2").doubleValue(), 0.001);
+
         // check with a smaller interval
         interval = new Interval(start.plusMillis(2), start.plusMillis(6));
-        result = underTest.getActiveColumnsByToTV("roomName", interval, 100);
+        result = underTest.getActiveColumnsByToTV("roomName", interval, 100, true);
         assertEquals(3, result.size());
         Map.Entry<String, Double> firstEntry = result.entrySet().iterator().next();
         assertEquals("r4", firstEntry.getKey());
@@ -221,31 +240,32 @@ public class MentionableDAOTest {
         IMessageSummaryDAO msgSummaryDao =  ChatAlyticsDAOFactory.createMessageSummaryDAO(config);
         msgSummaryDao.startAsync().awaitRunning();
 
-        underTest.persistValue(new EmojiEntity("u1", "r1", start.plusMillis(1), "a", 1, false));
+        underTest.persistValue(new EmojiEntity("u1", "r1", start.plusMillis(1), "a", 1, true));
         underTest.persistValue(new EmojiEntity("u2", "r1", start.plusMillis(3), "c", 1, false));
-        underTest.persistValue(new EmojiEntity("u1", "r2", start.plusMillis(4), "a", 1, false));
+        underTest.persistValue(new EmojiEntity("u1", "r2", start.plusMillis(4), "a", 1, true));
 
         msgSummaryDao.persistMessageSummary(new MessageSummary("u1", "r1", start.plusMillis(1),
-                                                               MESSAGE, 1, false));
+                                                               MESSAGE, 1, true));
         msgSummaryDao.persistMessageSummary(new MessageSummary("u1", "r1", start.plusMillis(1),
-                                                               MESSAGE, 1, false));
+                                                               MESSAGE, 1, true));
         msgSummaryDao.persistMessageSummary(new MessageSummary("u1", "r1", start.plusMillis(1),
-                                                               CHANNEL_JOIN, 1, false));
+                                                               CHANNEL_JOIN, 1, true));
         msgSummaryDao.persistMessageSummary(new MessageSummary("u2", "r1", start.plusMillis(1),
                                                                MESSAGE, 1, false));
         msgSummaryDao.persistMessageSummary(new MessageSummary("u2", "r1", start.plusMillis(1),
                                                                CHANNEL_JOIN, 1, false));
         msgSummaryDao.persistMessageSummary(new MessageSummary("u1", "r2", start.plusMillis(1),
-                                                               MESSAGE, 1, false));
+                                                               MESSAGE, 1, true));
         msgSummaryDao.persistMessageSummary(new MessageSummary("u3", "r2", start.plusMillis(1),
                                                                MESSAGE, 1, false));
         msgSummaryDao.persistMessageSummary(new MessageSummary("u1", "r2", start.plusMillis(1),
-                                                               MESSAGE_CHANGED, 1, false));
+                                                               MESSAGE_CHANGED, 1, true));
 
-        Map<String, Double> result = underTest.getActiveColumnsByToMV("username", interval, 100);
+        Map<String, Double> result = underTest.getActiveColumnsByToMV("username", interval, 100,
+                                                                      true);
         assertEquals(2, result.size());
-        // u1 has 3 messages and 2 emojis. u2 has 2 messages and 1 emoji. Total message volume is 5
-        // u1 should be 2/5 and u2 should be 1/5
+        // u1 has 3 messages and 2 emojis. u2 has 1 message and 1 emoji. u3 has 1 message.
+        // Total message volume is 5. u1 should be 2/5 and u2 should be 1/5
         assertEquals(0.4, result.get("u1").doubleValue(), 0);
         assertEquals(0.2, result.get("u2").doubleValue(), 0);
 
@@ -255,9 +275,16 @@ public class MentionableDAOTest {
             assertTrue(Double.compare(value, previousValue) > 0);
         }
 
+        // exclude bots
+        result = underTest.getActiveColumnsByToMV("username", interval, 100, false);
+        assertEquals(1, result.size());
+        // u1 is a bot. u2 has 1 messages and 1 emoji. u3 has 1 message. Total message volume is 2
+        // u1 will get excluded u2 should be 1/2
+        assertEquals(0.5, result.get("u2").doubleValue(), 0);
+
         // check with a smaller interval
         interval = new Interval(start.plusMillis(2), start.plusMillis(6));
-        result = underTest.getActiveColumnsByToTV("username", interval, 100);
+        result = underTest.getActiveColumnsByToTV("username", interval, 100, true);
         assertEquals(2, result.size());
         assertEquals(0.5, result.get("u1").doubleValue(), 0);
         assertEquals(0.5, result.get("u2").doubleValue(), 0);

--- a/compute/src/test/java/com/chatalytics/compute/db/dao/MessageSummaryDAOImplTest.java
+++ b/compute/src/test/java/com/chatalytics/compute/db/dao/MessageSummaryDAOImplTest.java
@@ -87,7 +87,8 @@ public class MessageSummaryDAOImplTest {
         Interval interval = new Interval(mentionDate.minusDays(1),  mentionDate.plusDays(1));
         List<MessageSummary> result = underTest.getAllMessageSummaries(interval,
                                                                        ImmutableList.of("room1"),
-                                                                       ImmutableList.of("user1"));
+                                                                       ImmutableList.of("user1"),
+                                                                       true);
         assertEquals(1, result.size());
     }
 
@@ -104,8 +105,10 @@ public class MessageSummaryDAOImplTest {
     @Test
     public void testGetTotalMessageSummaries() {
         Interval interval = new Interval(mentionDate.minusDays(1),  mentionDate.plusDays(1));
-        int result = underTest.getTotalMessageSummaries(interval, ImmutableList.of(),
-                                                        ImmutableList.of());
+        int result = underTest.getTotalMessageSummaries(interval,
+                                                        ImmutableList.of(),
+                                                        ImmutableList.of(),
+                                                        true);
         assertEquals(4, result);
     }
 
@@ -113,8 +116,10 @@ public class MessageSummaryDAOImplTest {
     public void testGetTotalMessageSummariesForType_withValue() {
         Interval interval = new Interval(mentionDate.minusDays(1),  mentionDate.plusDays(1));
         int result = underTest.getTotalMessageSummariesForType(MessageType.MESSAGE,
-                                                        interval, ImmutableList.of(),
-                                                        ImmutableList.of());
+                                                               interval,
+                                                               ImmutableList.of(),
+                                                               ImmutableList.of(),
+                                                               true);
         assertEquals(2, result);
     }
 
@@ -123,12 +128,12 @@ public class MessageSummaryDAOImplTest {
         Interval interval = new Interval(mentionDate.minusMillis(1), mentionDate.plusMillis(1));
 
         Map<String, Double> result =
-                underTest.getActiveRoomsByMethod(interval, ActiveMethod.ToTV, 10);
+                underTest.getActiveRoomsByMethod(interval, ActiveMethod.ToTV, 10, true);
         assertEquals(2, result.size());
         assertEquals(0.5, result.get("room1"), 0);
         assertEquals(0.5, result.get("room2"), 0);
 
-        result = underTest.getActiveRoomsByMethod(interval, ActiveMethod.ToMV, 10);
+        result = underTest.getActiveRoomsByMethod(interval, ActiveMethod.ToMV, 10, true);
         assertEquals(2, result.size());
         assertEquals(1.0, result.get("room1"), 0);
         assertEquals(1.0, result.get("room2"), 0);
@@ -139,14 +144,14 @@ public class MessageSummaryDAOImplTest {
         Interval interval = new Interval(mentionDate.minusMillis(1), mentionDate.plusMillis(1));
 
         Map<String, Double> result =
-                underTest.getActiveUsersByMethod(interval, ActiveMethod.ToTV, 10);
+                underTest.getActiveUsersByMethod(interval, ActiveMethod.ToTV, 10, true);
         assertEquals(4, result.size());
         assertEquals(0.25, result.get("user1"), 0);
         assertEquals(0.25, result.get("user2"), 0);
         assertEquals(0.25, result.get("user3"), 0);
         assertEquals(0.25, result.get("user4"), 0);
 
-        result = underTest.getActiveUsersByMethod(interval, ActiveMethod.ToMV, 10);
+        result = underTest.getActiveUsersByMethod(interval, ActiveMethod.ToMV, 10, true);
         assertEquals(4, result.size());
         assertEquals(0.5, result.get("user1"), 0);
         assertEquals(0.5, result.get("user2"), 0);

--- a/web/src/main/java/com/chatalytics/web/constant/WebConstants.java
+++ b/web/src/main/java/com/chatalytics/web/constant/WebConstants.java
@@ -35,4 +35,8 @@ public class WebConstants {
      */
     public static final String TOP_N = "n";
 
+    /**
+     * Constant used in endpoints for specifying whether bots should be included in calculations
+     */
+    public static final String BOT = "bot";
 }

--- a/web/src/main/java/com/chatalytics/web/utils/ResourceUtils.java
+++ b/web/src/main/java/com/chatalytics/web/utils/ResourceUtils.java
@@ -49,6 +49,22 @@ public class ResourceUtils {
     }
 
     /**
+     * Helper method that returns an {@link Optional} with the value set if the parameter is not
+     * null or non-empty.
+     *
+     * @param parameterStr
+     *            The parameter to create the {@link Optional} for.
+     * @return An {@link Optional} with the value set or absent appropriately.
+     */
+    public static Optional<Boolean> getOptionalForParameterAsBool(String parameterStr) {
+        if (parameterStr == null || parameterStr.isEmpty()) {
+            return Optional.absent();
+        } else {
+            return Optional.of(Boolean.parseBoolean(parameterStr));
+        }
+    }
+
+    /**
      * Checks to see if the passed in list is null. If it is it creates an empty one. Note that the
      * empty list it returns is a singleton immutable list
      *

--- a/web/src/test/java/com/chatalytics/web/resources/EmojisResourceTest.java
+++ b/web/src/test/java/com/chatalytics/web/resources/EmojisResourceTest.java
@@ -94,21 +94,21 @@ public class EmojisResourceTest {
         Map<String, Long> response = underTest.getTopEmojis(startTimeStr, endTimeStr,
                                                             ImmutableList.of("u1"),
                                                             ImmutableList.of("r1"),
-                                                            null);
+                                                            null, null);
         Map<String, Long> expected = Maps.newHashMap();
         expected.put("e1", 5L);
         expected.put("e2", 1L);
         assertEquals(expected, response);
 
         response = underTest.getTopEmojis(startTimeStr, endTimeStr, ImmutableList.of("u1"),
-                                          null, null);
+                                          null, null, null);
         expected.clear();
         expected.put("e1", 5L);
         expected.put("e4", 3L);
         expected.put("e2", 1L);
         assertEquals(expected, response);
 
-        response = underTest.getTopEmojis(startTimeStr, endTimeStr, null, null, null);
+        response = underTest.getTopEmojis(startTimeStr, endTimeStr, null, null, null, null);
         expected.clear();
         expected.put("e2", 14L);
         expected.put("e1", 11L);
@@ -122,7 +122,8 @@ public class EmojisResourceTest {
         DateTimeFormatter dtf = DateTimeUtils.PARAMETER_WITH_DAY_DTF.withZone(dtZone);
         String startTimeStr = dtf.print(mentionTime.minusDays(1));
         String endTimeStr = dtf.print(mentionTime.plusDays(1));
-        List<EmojiEntity> result = underTest.getAllEmojis(startTimeStr, endTimeStr, null, null);
+        List<EmojiEntity> result = underTest.getAllEmojis(startTimeStr, endTimeStr, null, null,
+                                                          null);
         assertEquals(emojis.size(), result.size());
 
         Set<EmojiEntity> resultEmojiSet = Sets.newHashSet(result);
@@ -142,7 +143,7 @@ public class EmojisResourceTest {
 
         LabeledDenseMatrix<String> ldm = underTest.getSimilarities(
                 startTimeStr, endTimeStr, DimensionType.ROOM.getDimensionName(),
-                DimensionType.EMOJI.getDimensionName());
+                DimensionType.EMOJI.getDimensionName(), null);
         assertEquals(4, ldm.getLabels().size());
         assertEquals(4, ldm.getMatrix().length);
     }
@@ -158,7 +159,7 @@ public class EmojisResourceTest {
 
         LabeledDenseMatrix<String> ldm = underTest.getSimilarities(
                 startTimeStr, endTimeStr, DimensionType.USER.getDimensionName(),
-                DimensionType.EMOJI.getDimensionName());
+                DimensionType.EMOJI.getDimensionName(), null);
         assertEquals(4, ldm.getLabels().size());
         assertEquals(4, ldm.getMatrix().length);
     }
@@ -170,7 +171,7 @@ public class EmojisResourceTest {
         String endTimeStr = dtf.print(mentionTime.plusDays(1));
         underTest.getSimilarities(startTimeStr, endTimeStr,
                                   DimensionType.ROOM.getDimensionName(),
-                                  DimensionType.ROOM.getDimensionName());
+                                  DimensionType.ROOM.getDimensionName(), "true");
     }
 
     @Test
@@ -180,7 +181,8 @@ public class EmojisResourceTest {
         String endTimeStr = dtf.print(mentionTime.plusDays(1));
         Map<String, Double> scores = underTest.getActive(startTimeStr, endTimeStr,
                                                          DimensionType.USER.toString(),
-                                                         ActiveMethod.ToTV.toString(), "10");
+                                                         ActiveMethod.ToTV.toString(), "10",
+                                                         "true");
 
         assertFalse(scores.isEmpty());
     }
@@ -192,7 +194,8 @@ public class EmojisResourceTest {
         String endTimeStr = dtf.print(mentionTime.plusDays(1));
         Map<String, Double> scores = underTest.getActive(startTimeStr, endTimeStr,
                                                          DimensionType.ROOM.toString(),
-                                                         ActiveMethod.ToTV.toString(), "10");
+                                                         ActiveMethod.ToTV.toString(), "10",
+                                                         "true");
 
         assertFalse(scores.isEmpty());
     }
@@ -204,7 +207,8 @@ public class EmojisResourceTest {
         String endTimeStr = dtf.print(mentionTime.plusDays(1));
         Map<String, Double> scores = underTest.getActive(startTimeStr, endTimeStr,
                                                          DimensionType.USER.toString(),
-                                                         ActiveMethod.ToMV.toString(), "10");
+                                                         ActiveMethod.ToMV.toString(), "10",
+                                                         "true");
         assertFalse(scores.isEmpty());
     }
 
@@ -215,7 +219,8 @@ public class EmojisResourceTest {
         String endTimeStr = dtf.print(mentionTime.plusDays(1));
         Map<String, Double> scores =  underTest.getActive(startTimeStr, endTimeStr,
                                                           DimensionType.ROOM.toString(),
-                                                          ActiveMethod.ToMV.toString(), "10");
+                                                          ActiveMethod.ToMV.toString(), "10",
+                                                          "true");
         assertFalse(scores.isEmpty());
     }
 
@@ -225,7 +230,7 @@ public class EmojisResourceTest {
         String startTimeStr = dtf.print(mentionTime.minusDays(1));
         String endTimeStr = dtf.print(mentionTime.plusDays(1));
         underTest.getActive(startTimeStr, endTimeStr, DimensionType.EMOJI.toString(),
-                                ActiveMethod.ToTV.toString(), "10");
+                                ActiveMethod.ToTV.toString(), "10", "true");
     }
 
     @Test

--- a/web/src/test/java/com/chatalytics/web/resources/EntitiesResourceTest.java
+++ b/web/src/test/java/com/chatalytics/web/resources/EntitiesResourceTest.java
@@ -87,21 +87,22 @@ public class EntitiesResourceTest {
         String endTimeStr = dtf.print(mentionTime.plusDays(1));
         Map<String, Long> response = underTest.getTrendingTopics(startTimeStr, endTimeStr,
                                                                  ImmutableList.of("u1"),
-                                                                 ImmutableList.of("r1"), null);
+                                                                 ImmutableList.of("r1"),
+                                                                 null, null);
         Map<String, Long> expected = Maps.newHashMap();
         expected.put("e1", 5L);
         expected.put("e2", 1L);
         assertEquals(expected, response);
 
         response = underTest.getTrendingTopics(startTimeStr, endTimeStr, ImmutableList.of("u1"),
-                                               null, null);
+                                               null, null, null);
         expected.clear();
         expected.put("e1", 5L);
         expected.put("e4", 3L);
         expected.put("e2", 1L);
         assertEquals(expected, response);
 
-        response = underTest.getTrendingTopics(startTimeStr, endTimeStr, null, null, null);
+        response = underTest.getTrendingTopics(startTimeStr, endTimeStr, null, null, null, null);
         expected.clear();
         expected.put("e2", 14L);
         expected.put("e1", 11L);
@@ -115,7 +116,8 @@ public class EntitiesResourceTest {
         DateTimeFormatter dtf = DateTimeUtils.PARAMETER_WITH_DAY_DTF.withZone(dtZone);
         String startTimeStr = dtf.print(mentionTime.minusDays(1));
         String endTimeStr = dtf.print(mentionTime.plusDays(1));
-        List<ChatEntity> result = underTest.getAllEntites(startTimeStr, endTimeStr, null, null);
+        List<ChatEntity> result = underTest.getAllEntites(startTimeStr, endTimeStr, null, null,
+                                                          null);
         assertEquals(entities.size(), result.size());
 
         Set<ChatEntity> resultEntitySet = Sets.newHashSet(result);
@@ -136,7 +138,7 @@ public class EntitiesResourceTest {
 
         LabeledDenseMatrix<String> ldm = underTest.getSimilarities(
                 startTimeStr, endTimeStr, DimensionType.ROOM.getDimensionName(),
-                DimensionType.ENTITY.getDimensionName());
+                DimensionType.ENTITY.getDimensionName(), null);
         assertEquals(4, ldm.getLabels().size());
         assertEquals(4, ldm.getMatrix().length);
     }
@@ -152,7 +154,7 @@ public class EntitiesResourceTest {
 
         LabeledDenseMatrix<String> ldm = underTest.getSimilarities(
                 startTimeStr, endTimeStr, DimensionType.USER.getDimensionName(),
-                DimensionType.ENTITY.getDimensionName());
+                DimensionType.ENTITY.getDimensionName(), null);
         assertEquals(4, ldm.getLabels().size());
         assertEquals(4, ldm.getMatrix().length);
     }
@@ -164,7 +166,7 @@ public class EntitiesResourceTest {
         String endTimeStr = dtf.print(mentionTime.plusDays(1));
         underTest.getSimilarities(startTimeStr, endTimeStr,
                                   DimensionType.ROOM.getDimensionName(),
-                                  DimensionType.ROOM.getDimensionName());
+                                  DimensionType.ROOM.getDimensionName(), "true");
     }
 
     @Test
@@ -174,7 +176,8 @@ public class EntitiesResourceTest {
         String endTimeStr = dtf.print(mentionTime.plusDays(1));
         Map<String, Double> scores = underTest.getActive(startTimeStr, endTimeStr,
                                                          DimensionType.USER.toString(),
-                                                         ActiveMethod.ToTV.toString(), "10");
+                                                         ActiveMethod.ToTV.toString(), "10",
+                                                         "true");
 
         assertFalse(scores.isEmpty());
     }
@@ -186,7 +189,8 @@ public class EntitiesResourceTest {
         String endTimeStr = dtf.print(mentionTime.plusDays(1));
         Map<String, Double> scores = underTest.getActive(startTimeStr, endTimeStr,
                                                          DimensionType.ROOM.toString(),
-                                                         ActiveMethod.ToTV.toString(), "10");
+                                                         ActiveMethod.ToTV.toString(), "10",
+                                                         "true");
 
         assertFalse(scores.isEmpty());
     }
@@ -198,7 +202,8 @@ public class EntitiesResourceTest {
         String endTimeStr = dtf.print(mentionTime.plusDays(1));
         Map<String, Double> scores = underTest.getActive(startTimeStr, endTimeStr,
                                                          DimensionType.USER.toString(),
-                                                         ActiveMethod.ToMV.toString(), "10");
+                                                         ActiveMethod.ToMV.toString(), "10",
+                                                         "true");
         assertFalse(scores.isEmpty());
     }
 
@@ -209,7 +214,8 @@ public class EntitiesResourceTest {
         String endTimeStr = dtf.print(mentionTime.plusDays(1));
         Map<String, Double> scores = underTest.getActive(startTimeStr, endTimeStr,
                                                          DimensionType.ROOM.toString(),
-                                                         ActiveMethod.ToMV.toString(), "10");
+                                                         ActiveMethod.ToMV.toString(), "10",
+                                                         "true");
         assertFalse(scores.isEmpty());
     }
 
@@ -219,7 +225,7 @@ public class EntitiesResourceTest {
         String startTimeStr = dtf.print(mentionTime.minusDays(1));
         String endTimeStr = dtf.print(mentionTime.plusDays(1));
         underTest.getActive(startTimeStr, endTimeStr, DimensionType.EMOJI.toString(),
-                                ActiveMethod.ToTV.toString(), "10");
+                            ActiveMethod.ToTV.toString(), "10", "true");
     }
 
     @After

--- a/web/src/test/java/com/chatalytics/web/resources/MessageSummaryResourceTest.java
+++ b/web/src/test/java/com/chatalytics/web/resources/MessageSummaryResourceTest.java
@@ -57,7 +57,7 @@ public class MessageSummaryResourceTest {
         mentionTime = DateTime.now().withZone(DateTimeZone.UTC);
 
         sums = Lists.newArrayList();
-        sums.add(new MessageSummary("u1", "r1", mentionTime.minus(1), BOT_MESSAGE, 1, true));
+        sums.add(new MessageSummary("u1", "r1", mentionTime.minus(1), BOT_MESSAGE, 1, false));
         sums.add(new MessageSummary("u2", "r1", mentionTime.minus(2), MESSAGE, 1, false));
         sums.add(new MessageSummary("u2", "r2", mentionTime.minus(3), CHANNEL_JOIN, 1, false));
         sums.add(new MessageSummary("u3", "r1", mentionTime.minus(4), MESSAGE, 1, false));
@@ -74,7 +74,7 @@ public class MessageSummaryResourceTest {
         String startTimeStr = dtf.print(mentionTime.minusDays(1));
         String endTimeStr = dtf.print(mentionTime.plusDays(1));
         List<MessageSummary> result = underTest.getAllMessageSummaries(startTimeStr, endTimeStr,
-                                                                       null, null, null);
+                                                                       null, null, null, null);
         assertEquals(sums.size(), result.size());
 
         Set<MessageSummary> resultMessageSummarySet = Sets.newHashSet(result);
@@ -83,7 +83,7 @@ public class MessageSummaryResourceTest {
         }
 
         result = underTest.getAllMessageSummaries(startTimeStr, endTimeStr, null, null,
-                                                  BOT_MESSAGE.toString());
+                                                  BOT_MESSAGE.toString(), null);
         assertEquals(1, result.size());
         assertEquals(BOT_MESSAGE, result.get(0).getValue());
     }
@@ -94,19 +94,20 @@ public class MessageSummaryResourceTest {
         DateTimeFormatter dtf = DateTimeUtils.PARAMETER_WITH_DAY_DTF.withZone(dtZone);
         String startTimeStr = dtf.print(mentionTime.minusDays(1));
         String endTimeStr = dtf.print(mentionTime.plusDays(1));
-        int result = underTest.getTotalMessageSummaries(startTimeStr, endTimeStr, null, null, null);
+        int result = underTest.getTotalMessageSummaries(startTimeStr, endTimeStr, null, null, null,
+                                                        null);
         assertEquals(sums.size(), result);
 
         result = underTest.getTotalMessageSummaries(startTimeStr, endTimeStr,
-                                                    ImmutableList.of("u1"), null, null);
+                                                    ImmutableList.of("u1"), null, null, null);
         assertEquals(1, result);
 
         result = underTest.getTotalMessageSummaries(startTimeStr, endTimeStr, null,
-                                                    ImmutableList.of("r1"), null);
+                                                    ImmutableList.of("r1"), null, null);
         assertEquals(3, result);
 
         result = underTest.getTotalMessageSummaries(startTimeStr, endTimeStr, null, null,
-                                                    MESSAGE.toString());
+                                                    MESSAGE.toString(), null);
         assertEquals(2, result);
     }
 
@@ -117,7 +118,8 @@ public class MessageSummaryResourceTest {
         String endTimeStr = dtf.print(mentionTime.plusDays(1));
         Map<String, Double> scores = underTest.getActive(startTimeStr, endTimeStr,
                                                          DimensionType.USER.toString(),
-                                                         ActiveMethod.ToTV.toString(), "10");
+                                                         ActiveMethod.ToTV.toString(), "10",
+                                                         "true");
 
         assertFalse(scores.isEmpty());
     }
@@ -129,7 +131,8 @@ public class MessageSummaryResourceTest {
         String endTimeStr = dtf.print(mentionTime.plusDays(1));
         Map<String, Double> scores = underTest.getActive(startTimeStr, endTimeStr,
                                                          DimensionType.ROOM.toString(),
-                                                         ActiveMethod.ToTV.toString(), "10");
+                                                         ActiveMethod.ToTV.toString(), "10",
+                                                         "true");
 
         assertFalse(scores.isEmpty());
     }
@@ -141,7 +144,8 @@ public class MessageSummaryResourceTest {
         String endTimeStr = dtf.print(mentionTime.plusDays(1));
         Map<String, Double> scores = underTest.getActive(startTimeStr, endTimeStr,
                                                          DimensionType.USER.toString(),
-                                                         ActiveMethod.ToMV.toString(), "10");
+                                                         ActiveMethod.ToMV.toString(), "10",
+                                                         "true");
         assertFalse(scores.isEmpty());
     }
 
@@ -152,7 +156,8 @@ public class MessageSummaryResourceTest {
         String endTimeStr = dtf.print(mentionTime.plusDays(1));
         Map<String, Double> scores = underTest.getActive(startTimeStr, endTimeStr,
                                                          DimensionType.ROOM.toString(),
-                                                         ActiveMethod.ToMV.toString(), "10");
+                                                         ActiveMethod.ToMV.toString(), "10",
+                                                         "true");
         assertFalse(scores.isEmpty());
     }
 
@@ -162,7 +167,7 @@ public class MessageSummaryResourceTest {
         String startTimeStr = dtf.print(mentionTime.minusDays(1));
         String endTimeStr = dtf.print(mentionTime.plusDays(1));
         underTest.getActive(startTimeStr, endTimeStr, DimensionType.EMOJI.toString(),
-                            ActiveMethod.ToTV.toString(), "10");
+                            ActiveMethod.ToTV.toString(), "10", "true");
     }
 
     @After

--- a/web/src/test/java/com/chatalytics/web/utils/ResourceUtilsTest.java
+++ b/web/src/test/java/com/chatalytics/web/utils/ResourceUtilsTest.java
@@ -37,4 +37,30 @@ public class ResourceUtilsTest {
         List<String> test = Lists.newArrayList("a", "b");
         assertEquals(test, ResourceUtils.getListFromNullable(test));
     }
+
+    @Test
+    public void testGetOptionalForParameterAsInt() {
+        Optional<Integer> result = ResourceUtils.getOptionalForParameterAsInt(null);
+        assertEquals(Optional.absent(), result);
+
+        result = ResourceUtils.getOptionalForParameterAsInt("");
+        assertEquals(Optional.absent(), result);
+
+        int value = 2;
+        result = ResourceUtils.getOptionalForParameterAsInt(Integer.toString(value));
+        assertEquals(value, result.get().intValue());
+    }
+
+    @Test
+    public void testGetOptionalForParameterAsBool() {
+        Optional<Boolean> result = ResourceUtils.getOptionalForParameterAsBool(null);
+        assertEquals(Optional.absent(), result);
+
+        result = ResourceUtils.getOptionalForParameterAsBool("");
+        assertEquals(Optional.absent(), result);
+
+        boolean value = false;
+        result = ResourceUtils.getOptionalForParameterAsBool(Boolean.toString(value));
+        assertEquals(value, result.get().booleanValue());
+    }
 }


### PR DESCRIPTION
- Now that the mentionables have a bot field it can be exposed in all resources and DAOs so that an API caller can specify if they want to include bots in realtime calculations.
- Set the default value for bot inclusion to false
