### PR TITLE
Moving realtime to web.realtime in compute

### DIFF
--- a/compute/src/main/java/com/chatalytics/compute/ChatAlyticsEngineMain.java
+++ b/compute/src/main/java/com/chatalytics/compute/ChatAlyticsEngineMain.java
@@ -1,10 +1,10 @@
 package com.chatalytics.compute;
 
 import com.chatalytics.compute.db.dao.ChatAlyticsDAOFactory;
-import com.chatalytics.compute.realtime.ComputeRealtimeServer;
-import com.chatalytics.compute.realtime.ComputeRealtimeServerFactory;
 import com.chatalytics.compute.storm.ChatAlyticsService;
 import com.chatalytics.compute.storm.ChatAlyticsStormTopology;
+import com.chatalytics.compute.web.realtime.ComputeRealtimeServer;
+import com.chatalytics.compute.web.realtime.ComputeRealtimeServerFactory;
 import com.chatalytics.core.CommonCLIBuilder;
 import com.chatalytics.core.config.ChatAlyticsConfig;
 import com.chatalytics.core.util.YamlUtils;

--- a/compute/src/main/java/com/chatalytics/compute/storm/ChatAlyticsService.java
+++ b/compute/src/main/java/com/chatalytics/compute/storm/ChatAlyticsService.java
@@ -2,7 +2,7 @@ package com.chatalytics.compute.storm;
 
 import com.chatalytics.compute.ChatAlyticsEngineMain;
 import com.chatalytics.compute.config.ConfigurationConstants;
-import com.chatalytics.compute.realtime.ComputeRealtimeServer;
+import com.chatalytics.compute.web.realtime.ComputeRealtimeServer;
 import com.chatalytics.core.config.ChatAlyticsConfig;
 import com.chatalytics.core.util.YamlUtils;
 import com.google.common.util.concurrent.AbstractIdleService;

--- a/compute/src/main/java/com/chatalytics/compute/storm/bolt/RealtimeBolt.java
+++ b/compute/src/main/java/com/chatalytics/compute/storm/bolt/RealtimeBolt.java
@@ -27,7 +27,7 @@ import javax.websocket.EncodeException;
 import javax.websocket.Session;
 import javax.websocket.WebSocketContainer;
 
-import static com.chatalytics.compute.realtime.RealtimeResource.RT_COMPUTE_ENDPOINT;
+import static com.chatalytics.compute.web.realtime.RealtimeResource.RT_COMPUTE_ENDPOINT;
 import static com.google.common.base.CaseFormat.LOWER_UNDERSCORE;
 import static com.google.common.base.CaseFormat.UPPER_CAMEL;
 

--- a/compute/src/main/java/com/chatalytics/compute/web/realtime/ComputeRealtimeServer.java
+++ b/compute/src/main/java/com/chatalytics/compute/web/realtime/ComputeRealtimeServer.java
@@ -1,4 +1,4 @@
-package com.chatalytics.compute.realtime;
+package com.chatalytics.compute.web.realtime;
 
 import com.google.common.util.concurrent.AbstractIdleService;
 

--- a/compute/src/main/java/com/chatalytics/compute/web/realtime/ComputeRealtimeServerFactory.java
+++ b/compute/src/main/java/com/chatalytics/compute/web/realtime/ComputeRealtimeServerFactory.java
@@ -1,4 +1,4 @@
-package com.chatalytics.compute.realtime;
+package com.chatalytics.compute.web.realtime;
 
 import com.chatalytics.compute.web.resources.StatusResource;
 import com.chatalytics.core.config.ChatAlyticsConfig;

--- a/compute/src/main/java/com/chatalytics/compute/web/realtime/RealtimeResource.java
+++ b/compute/src/main/java/com/chatalytics/compute/web/realtime/RealtimeResource.java
@@ -1,4 +1,4 @@
-package com.chatalytics.compute.realtime;
+package com.chatalytics.compute.web.realtime;
 
 import com.chatalytics.core.model.data.ChatAlyticsEvent;
 import com.chatalytics.core.realtime.ChatAlyticsEventDecoder;

--- a/compute/src/test/java/com/chatalytics/compute/web/resources/StatusResourceTest.java
+++ b/compute/src/test/java/com/chatalytics/compute/web/resources/StatusResourceTest.java
@@ -1,0 +1,27 @@
+package com.chatalytics.compute.web.resources;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Tests {@link StatusResource}
+ *
+ * @author giannis
+ */
+public class StatusResourceTest {
+
+    private StatusResource underTest;
+
+    @Before
+    public void setUp() {
+        underTest = new StatusResource();
+    }
+
+    @Test
+    public void testHealth() {
+        String result = underTest.health();
+        assertEquals("OK", result);
+    }
+}

--- a/web/src/test/java/com/chatalytics/web/resources/EventsResourceTest.java
+++ b/web/src/test/java/com/chatalytics/web/resources/EventsResourceTest.java
@@ -13,7 +13,7 @@ import javax.websocket.CloseReason;
 import javax.websocket.RemoteEndpoint.Async;
 import javax.websocket.Session;
 
-import static com.chatalytics.compute.realtime.RealtimeResource.RT_COMPUTE_ENDPOINT;
+import static com.chatalytics.compute.web.realtime.RealtimeResource.RT_COMPUTE_ENDPOINT;
 import static com.chatalytics.web.resources.EventsResource.RT_EVENT_ENDPOINT;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;


### PR DESCRIPTION
- Moving the realtime package under web. This is clearer especially now that there's other web resources too
- Add a unit test for the status resource
