### PR TITLE
Fixing up Dockerfile and start script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,4 +17,4 @@ RUN cp web/target/chatalytics-web-0.3-with-dependencies.jar ${CHATALYTICSDIR}
 RUN cp compute/target/chatalytics-compute-0.3-with-dependencies.jar ${CHATALYTICSDIR}
 
 # Run ChatAlytics
-CMD ./bin/start-web-compute.sh
+CMD ./bin/start-web-compute.sh chatalytics-local.yaml

--- a/README.md
+++ b/README.md
@@ -27,13 +27,13 @@ To start the container in the backgroung based on that image run:
 `docker run -d --name chatalytics chatalytics`
 
 You should be able to see the container running by executing:
-`docker ps`
+`docker ps -f name=chatalytics -a`
 
 To ssh into the container run:
 `docker exec -i -t chatalytics bash`
 
 To stop the container run:
-`docker stop`
+`docker stop chatalytics`
 
 To remove old containers run:
 `docker rm chatalytics`

--- a/bin/start-web-compute.sh
+++ b/bin/start-web-compute.sh
@@ -1,9 +1,6 @@
 #!/bin/sh
 set -e
 
-# Kill all child processes if the main process exits
-trap 'jobs -p | xargs kill' EXIT
-
 if [ "$#" -ne 1 ]
 then
     echo "You haven't specified the configuration file"
@@ -12,16 +9,24 @@ fi
 
 config_file=$1
 
-echo "Starting web server with configuration: $config_file..."
-
-nohup java -cp\
-    chatalytics-web-0.3-with-dependencies.jar:config\
-    -Dlogback.configurationFile=config/web/logback.xml com.chatalytics.web.ServerMain\
-    -c $config_file > /dev/null 2>&1 &
-
 echo "Starting compute server with configuration: $config_file..."
 
-java -cp\
+sleep 15
+
+nohup java -cp\
     chatalytics-compute-0.3-with-dependencies.jar:config\
     -Dlogback.configurationFile=config/compute/logback.xml com.chatalytics.compute.ChatAlyticsEngineMain\
-    -c $config_file 2>&1 > /dev/null
+    -c $config_file 2>&1 > /dev/null &
+
+sleep_time_secs=5
+
+echo "Sleeping for $sleep_time_secs waiting for compute to start up"
+
+sleep $sleep_time_secs
+
+echo "Starting web server with configuration: $config_file..."
+
+java -cp\
+    chatalytics-web-0.3-with-dependencies.jar:config\
+    -Dlogback.configurationFile=config/web/logback.xml com.chatalytics.web.ServerMain\
+    -c $config_file

--- a/config/META-INF/persistence.xml
+++ b/config/META-INF/persistence.xml
@@ -20,17 +20,11 @@
                 useful for development, dangerous in production -->
             <property name="hibernate.hbm2ddl.auto" value="update" />
             <property name="java.naming.factory.initial" value=""/>
-            <property name="hibernate.dialect" value="org.hibernate.dialect.PostgreSQLDialect" />
-            <property name="hibernate.connection.provider_class" value="org.hibernate.hikaricp.internal.HikariCPConnectionProvider" />
-            <property name="hibernate.hikari.maximumPoolSize" value="32" />
-            <property name="hibernate.hikari.idleTimeout" value="0" />
-            <property name="hibernate.hikari.maxLifetime" value="120000" />
-            <property name="hibernate.hikari.leakDetectionThreshold" value="8000" />
-            <property name="hibernate.hikari.connectionTimeout" value="8000" />
-            <property name="hibernate.hikari.dataSourceClassName" value="org.postgresql.ds.PGSimpleDataSource" />
-            <property name="hibernate.hikari.dataSource.url" value="jdbc:postgresql://localhost:5432/chatalytics" />
-            <property name="hibernate.hikari.dataSource.user" value="chat_user" />
-            <property name="hibernate.hikari.dataSource.password" value="" />
+            <property name="hibernate.dialect" value="org.hibernate.dialect.H2Dialect" />
+            <property name="hibernate.connection.driver_class" value="org.h2.Driver" />
+            <property name="hibernate.connection.url" value="jdbc:h2:/mnt/chatalytics;AUTO_SERVER=true" />
+            <property name="hibernate.connection.username" value="" />
+            <property name="hibernate.connection.password" value="" />
             <property name="jadira.usertype.autoRegisterUserTypes" value="true" />
             <property name="jadira.usertype.javaZone" value="UTC" />
             <property name="jadira.usertype.databaseZone" value="UTC" />

--- a/config/chatalytics-local.yaml
+++ b/config/chatalytics-local.yaml
@@ -7,6 +7,6 @@ computeConfig:
         'com.chatalytics.bolts.sentiment.words': files/sentiment_words.csv
     chatConfig: !!com.chatalytics.core.config.LocalTestConfig
         randomSeed: 0
-        messageCorpusFile: corpus/test_corpus.txt
+        messageCorpusFile: compute/corpus/test_corpus.txt
 webConfig:
     port: 8080

--- a/web/src/main/java/com/chatalytics/web/ServerMain.java
+++ b/web/src/main/java/com/chatalytics/web/ServerMain.java
@@ -72,6 +72,8 @@ public class ServerMain extends Application {
         EventsResource eventResource = new EventsResource();
         RealtimeComputeClient computeClient = new RealtimeComputeClient(config, eventResource);
         ServerMain serverMain = new ServerMain(config, computeClient);
+
+        LOG.info("Starting compute client");
         serverMain.startComputeClient();
 
         // Start the server
@@ -85,6 +87,7 @@ public class ServerMain extends Application {
 
         addShutdownHook(computeClient);
 
+        LOG.info("Starting web server");
         server.start();
         server.join();
     }


### PR DESCRIPTION
- Fixed up the Dockerfile a bit to pass in config argument
- Added more logging to the web server
- Switched up the order of web and compute so that compute starts first. The web can now properly handshake with compute
- Switching the default persistence XML unit to H2
- Updating README instructions
