### PR TITLE
Add end date support for the slack backfiller

### DIFF
--- a/core/src/main/java/com/chatalytics/core/config/SlackBackfillerConfig.java
+++ b/core/src/main/java/com/chatalytics/core/config/SlackBackfillerConfig.java
@@ -19,4 +19,9 @@ public class SlackBackfillerConfig extends SlackConfig {
      */
     public String startDate;
 
+    /**
+     * Optional end date if you want the backfiller to stop emitting messages beyond this date
+     */
+    public String endDate;
+
 }

--- a/web/src/main/java/com/chatalytics/web/resources/UsersResource.java
+++ b/web/src/main/java/com/chatalytics/web/resources/UsersResource.java
@@ -26,7 +26,7 @@ import javax.ws.rs.core.MediaType;
 public class UsersResource {
 
     public static final String USER_ENDPOINT = WebConstants.API_PATH + "users";
-    private static final Logger LOG = LoggerFactory.getLogger(EmojisResource.class);
+    private static final Logger LOG = LoggerFactory.getLogger(UsersResource.class);
 
     private final IChatApiDAO chatApiDao;
 


### PR DESCRIPTION
- The backfiller spout will stop emitting once it reaches the end date
- Fix logger bug
