### PR TITLE
Added a start date for the slack spout

### DIFF
--- a/compute/src/main/java/com/chatalytics/compute/storm/spout/SlackBackfillSpout.java
+++ b/compute/src/main/java/com/chatalytics/compute/storm/spout/SlackBackfillSpout.java
@@ -66,13 +66,12 @@ public class SlackBackfillSpout extends BaseRichSpout {
 
         open(chatConfig, SlackApiDAOFactory.getSlackApiDao(config),
              ChatAlyticsDAOFactory.createChatAlyticsDao(config), context, collector);
-
     }
 
     @VisibleForTesting
     protected void open(SlackBackfillerConfig chatConfig, IChatApiDAO slackApiDao,
-                      IChatAlyticsDAO dbDao, TopologyContext context,
-                      SpoutOutputCollector collector) {
+                        IChatAlyticsDAO dbDao, TopologyContext context,
+                        SpoutOutputCollector collector) {
         this.granularityMins = chatConfig.granularityMins;
         this.collector = collector;
         this.slackDao = slackApiDao;

--- a/config/chatalytics-hipchat.yaml
+++ b/config/chatalytics-hipchat.yaml
@@ -5,6 +5,7 @@ computeConfig:
     classifier: compute/classifiers/english.all.3class.distsim.crf.ser.gz
     filesToRead:
         'com.chatalytics.bolts.sentiment.words': files/sentiment_words.csv
+    rtComputePort: 9000
     chatConfig: !!com.chatalytics.core.config.HipChatConfig
         baseAPIURL: https://api.hipchat.com/v1/
         authTokens: ['0']

--- a/config/chatalytics-local.yaml
+++ b/config/chatalytics-local.yaml
@@ -5,6 +5,7 @@ computeConfig:
     classifier: compute/classifiers/english.all.3class.distsim.crf.ser.gz
     filesToRead:
         'com.chatalytics.bolts.sentiment.words': files/sentiment_words.csv
+    rtComputePort: 9000
     chatConfig: !!com.chatalytics.core.config.LocalTestConfig
         randomSeed: 0
         messageCorpusFile: compute/corpus/test_corpus.txt

--- a/config/chatalytics-slack.yaml
+++ b/config/chatalytics-slack.yaml
@@ -5,6 +5,7 @@ computeConfig:
     classifier: compute/classifiers/english.all.3class.distsim.crf.ser.gz
     filesToRead:
         'com.chatalytics.bolts.sentiment.words': files/sentiment_words.csv
+    rtComputePort: 9000
     chatConfig: !!com.chatalytics.core.config.SlackConfig
         baseAPIURL: https://slack.com/api/
         authTokens: ['0']

--- a/config/chatalytics-slackbackfill.yaml
+++ b/config/chatalytics-slackbackfill.yaml
@@ -5,6 +5,7 @@ computeConfig:
     classifier: compute/classifiers/english.all.3class.distsim.crf.ser.gz
     filesToRead:
         'com.chatalytics.bolts.sentiment.words': files/sentiment_words.csv
+    rtComputePort: 9001
     chatConfig: !!com.chatalytics.core.config.SlackBackfillerConfig
         baseAPIURL: https://slack.com/api/
         authTokens: ['0']

--- a/core/src/main/java/com/chatalytics/core/config/SlackBackfillerConfig.java
+++ b/core/src/main/java/com/chatalytics/core/config/SlackBackfillerConfig.java
@@ -23,5 +23,4 @@ public class SlackBackfillerConfig extends SlackConfig {
      * Optional end date if you want the backfiller to stop emitting messages beyond this date
      */
     public String endDate;
-
 }

--- a/core/src/main/java/com/chatalytics/core/config/SlackConfig.java
+++ b/core/src/main/java/com/chatalytics/core/config/SlackConfig.java
@@ -14,6 +14,12 @@ public class SlackConfig implements ChatConfig {
 
     public char emojiEndChar = ':';
 
+    /**
+     * Optional start date. The spout will start processing records on and after this date. That
+     * means that it's inclusive of the date
+     */
+    public String startDate;
+
     @Override
     public List<String> getAuthTokens() {
         return authTokens;


### PR DESCRIPTION
- Added a start date that can work well with the end date in the backfill spout. This way one can set an end date on the slack backfill spout and a start date on the realtime slack spout.
- Changed the port on the backfill config to 9001. This is different than the realtime port, that's 9000
