### PR TITLE
There is already a startDate in SlackConfig

### DIFF
--- a/core/src/main/java/com/chatalytics/core/config/SlackBackfillerConfig.java
+++ b/core/src/main/java/com/chatalytics/core/config/SlackBackfillerConfig.java
@@ -15,11 +15,6 @@ public class SlackBackfillerConfig extends SlackConfig {
     public int granularityMins;
 
     /**
-     * The backfilling start date. Supports up to millisecond granularity. The format is ISO 8601.
-     */
-    public String startDate;
-
-    /**
      * Optional end date if you want the backfiller to stop emitting messages beyond this date
      */
     public String endDate;

--- a/core/src/main/java/com/chatalytics/core/config/SlackConfig.java
+++ b/core/src/main/java/com/chatalytics/core/config/SlackConfig.java
@@ -20,7 +20,7 @@ public class SlackConfig implements ChatConfig {
 
     /**
      * Optional start date. The spout will start processing records on and after this date. That
-     * means that it's inclusive of the date
+     * means that it's inclusive of the date. The format is ISO 8601.
      */
     public String startDate;
 


### PR DESCRIPTION
- The backfiller slack config doesn't need a start date anymore because the slack config parent has one too now
