### PR TITLE
RT sessions and Backpressure

### DIFF
--- a/compute/src/main/java/com/chatalytics/compute/storm/ChatAlyticsService.java
+++ b/compute/src/main/java/com/chatalytics/compute/storm/ChatAlyticsService.java
@@ -49,8 +49,9 @@ public class ChatAlyticsService extends AbstractIdleService {
 
         // enable backpressure since the spouts can move at a much faster speed than the bolts
         stormConfig.put(Config.TOPOLOGY_BACKPRESSURE_ENABLE, true);
-        stormConfig.put(Config.TOPOLOGY_EXECUTOR_RECEIVE_BUFFER_SIZE, 256);
-        stormConfig.put(Config.TOPOLOGY_EXECUTOR_SEND_BUFFER_SIZE, 128);
+        stormConfig.put(Config.TOPOLOGY_EXECUTOR_RECEIVE_BUFFER_SIZE, 64);
+        stormConfig.put(Config.TOPOLOGY_EXECUTOR_SEND_BUFFER_SIZE, 64);
+        stormConfig.put(Config.TOPOLOGY_SLEEP_SPOUT_WAIT_STRATEGY_TIME_MS, 100);
 
         stormConfig.setSkipMissingKryoRegistrations(true);
         stormConfig.put(ConfigurationConstants.CHATALYTICS_CONFIG.txt,

--- a/compute/src/main/java/com/chatalytics/compute/storm/bolt/RealtimeBolt.java
+++ b/compute/src/main/java/com/chatalytics/compute/storm/bolt/RealtimeBolt.java
@@ -98,7 +98,9 @@ public class RealtimeBolt extends ChatAlyticsBaseBolt {
                                              ConnectionType.PUBLISHER));
         try {
             LOG.info("Connecting to {}", rtURI);
-            return webSocketContainer.connectToServer(this, rtURI);
+            Session session = webSocketContainer.connectToServer(this, rtURI);
+            session.setMaxIdleTimeout(0);
+            return session;
         } catch (DeploymentException | IOException e) {
             throw new RuntimeException("Unable to connect to RT compute server. Is it up?");
         }

--- a/config/chatalytics-slackbackfill.yaml
+++ b/config/chatalytics-slackbackfill.yaml
@@ -12,7 +12,7 @@ computeConfig:
         granularityMins: 5
         startDate: '2013-11-01T00:00:00Z'
         endDate: null
-        includePrivateRooms: true
+        includePrivateRooms: false
         includeArchivedRooms: true
 webConfig:
     port: 8080

--- a/web/src/main/java/com/chatalytics/web/RealtimeComputeClient.java
+++ b/web/src/main/java/com/chatalytics/web/RealtimeComputeClient.java
@@ -62,6 +62,7 @@ public class RealtimeComputeClient extends AbstractIdleService {
                                              config.computeConfig.rtComputePath,
                                              ConnectionType.SUBSCRIBER));
         Session session = webSocketContainer.connectToServer(eventResource, rtURI);
+        session.setMaxIdleTimeout(0);
         LOG.info("Connected to realtime compute server");
         return session;
     }


### PR DESCRIPTION
- Set the idle timeout for realtime session to infinity because inactivity can cause them to be closed
- Set the sleep time to 100ms and lower some backpressure settings
