### PR TITLE
Setting idle timeout for sockets

### DIFF
--- a/compute/src/main/java/com/chatalytics/compute/web/realtime/RealtimeResource.java
+++ b/compute/src/main/java/com/chatalytics/compute/web/realtime/RealtimeResource.java
@@ -55,10 +55,10 @@ public class RealtimeResource {
     @OnOpen
     public void openSocket(@PathParam(RT_COMPUTE_ENDPOINT_PARAM) ConnectionType type,
                            Session session) {
+        session.setMaxIdleTimeout(0);
         if (type == ConnectionType.SUBSCRIBER) {
             LOG.info("Got a new subscriber connection request with ID {}. Saving session",
                      session.getId());
-
             // cleanup sessions
             Set<Session> closedSessions = Sets.newHashSet();
             for (Session existingSession : sessions) {

--- a/web/src/main/java/com/chatalytics/web/resources/EventsResource.java
+++ b/web/src/main/java/com/chatalytics/web/resources/EventsResource.java
@@ -50,6 +50,7 @@ public class EventsResource {
 
     @OnOpen
     public void onOpen(Session session) {
+        session.setMaxIdleTimeout(0);
         if (session.getRequestURI().getPath().startsWith(RT_EVENT_ENDPOINT)) {
             LOG.info("Got a new web subscription connection request with ID {}", session.getId());
             if (!connectedToCompute) {

--- a/web/src/test/java/com/chatalytics/web/resources/EventsResourceTest.java
+++ b/web/src/test/java/com/chatalytics/web/resources/EventsResourceTest.java
@@ -81,6 +81,7 @@ public class EventsResourceTest {
         underTest.onOpen(computeSession);
         assertEquals(0, underTest.getSessions().size());
         verify(computeSession).getRequestURI();
+        verify(computeSession).setMaxIdleTimeout(0);
         verifyNoMoreInteractions(computeSession);
         assertTrue(underTest.isConnectedToCompute());
 
@@ -91,6 +92,7 @@ public class EventsResourceTest {
         underTest.onOpen(firstClientSession);
         verify(firstClientSession).getRequestURI();
         verify(firstClientSession).getId();
+        verify(firstClientSession).setMaxIdleTimeout(0);
         verifyNoMoreInteractions(firstClientSession);
         assertEquals(1, underTest.getSessions().size());
         assertEquals(firstClientSession, underTest.getSessions().iterator().next());
@@ -103,6 +105,7 @@ public class EventsResourceTest {
         underTest.onOpen(secondClientSession);
         verify(secondClientSession).getRequestURI();
         verify(secondClientSession).getId();
+        verify(secondClientSession).setMaxIdleTimeout(0);
         verifyNoMoreInteractions(secondClientSession);
         assertEquals(1, underTest.getSessions().size());
         assertEquals(secondClientSession, underTest.getSessions().iterator().next());
@@ -116,6 +119,7 @@ public class EventsResourceTest {
         verifyNoMoreInteractions(secondClientSession);
         verify(thirdClientSession).getRequestURI();
         verify(thirdClientSession).getId();
+        verify(thirdClientSession).setMaxIdleTimeout(0);
         verifyNoMoreInteractions(thirdClientSession);
         assertEquals(2, underTest.getSessions().size());
 
@@ -140,6 +144,7 @@ public class EventsResourceTest {
         assertFalse(underTest.isConnectedToCompute());
 
         verify(computeSession, times(2)).getRequestURI();
+        verify(computeSession).setMaxIdleTimeout(0);
         verifyNoMoreInteractions(computeSession);
     }
 
@@ -155,6 +160,7 @@ public class EventsResourceTest {
         underTest.onOpen(computeSession);
         assertEquals(0, underTest.getSessions().size());
         verify(computeSession).getRequestURI();
+        verify(computeSession).setMaxIdleTimeout(0);
         verifyNoMoreInteractions(computeSession);
         assertTrue(underTest.isConnectedToCompute());
 
@@ -165,6 +171,7 @@ public class EventsResourceTest {
         underTest.onOpen(firstClientSession);
         verify(firstClientSession).getRequestURI();
         verify(firstClientSession).getId();
+        verify(firstClientSession).setMaxIdleTimeout(0);
         verifyNoMoreInteractions(firstClientSession);
         assertEquals(1, underTest.getSessions().size());
         assertEquals(firstClientSession, underTest.getSessions().iterator().next());
@@ -173,6 +180,7 @@ public class EventsResourceTest {
         verify(firstClientSession, times(2)).getRequestURI();
         verify(firstClientSession, times(2)).getId();
         verify(firstClientSession).close();
+        verify(firstClientSession).setMaxIdleTimeout(0);
         verifyNoMoreInteractions(firstClientSession);
         assertEquals(0, underTest.getSessions().size());
     }
@@ -189,6 +197,7 @@ public class EventsResourceTest {
         underTest.onOpen(computeSession);
         assertEquals(0, underTest.getSessions().size());
         verify(computeSession).getRequestURI();
+        verify(computeSession).setMaxIdleTimeout(0);
         verifyNoMoreInteractions(computeSession);
         assertTrue(underTest.isConnectedToCompute());
 
@@ -199,6 +208,7 @@ public class EventsResourceTest {
         underTest.onOpen(firstClientSession);
         verify(firstClientSession).getRequestURI();
         verify(firstClientSession).getId();
+        verify(firstClientSession).setMaxIdleTimeout(0);
         verifyNoMoreInteractions(firstClientSession);
         assertEquals(1, underTest.getSessions().size());
         assertEquals(firstClientSession, underTest.getSessions().iterator().next());
@@ -208,6 +218,7 @@ public class EventsResourceTest {
         verify(firstClientSession, times(2)).getRequestURI();
         verify(firstClientSession, times(3)).getId();
         verify(firstClientSession).close();
+        verify(firstClientSession).setMaxIdleTimeout(0);
         verifyNoMoreInteractions(firstClientSession);
         assertEquals(0, underTest.getSessions().size());
     }
@@ -226,6 +237,7 @@ public class EventsResourceTest {
         underTest.onOpen(computeSession);
         assertEquals(0, underTest.getSessions().size());
         verify(computeSession).getRequestURI();
+        verify(computeSession).setMaxIdleTimeout(0);
         verifyNoMoreInteractions(computeSession);
         assertTrue(underTest.isConnectedToCompute());
 
@@ -241,6 +253,7 @@ public class EventsResourceTest {
         underTest.onOpen(firstClientSession);
         verify(firstClientSession).getRequestURI();
         verify(firstClientSession).getId();
+        verify(firstClientSession).setMaxIdleTimeout(0);
         verifyNoMoreInteractions(firstClientSession);
         assertEquals(1, underTest.getSessions().size());
 
@@ -252,6 +265,7 @@ public class EventsResourceTest {
         underTest.onOpen(secondClientSession);
         verify(secondClientSession).getRequestURI();
         verify(secondClientSession).getId();
+        verify(secondClientSession).setMaxIdleTimeout(0);
         verifyNoMoreInteractions(secondClientSession);
         assertEquals(2, underTest.getSessions().size());
 


### PR DESCRIPTION
- Setting ALL web socket session timeouts to 0 so that they don't expire when the topology is inactive
