### PR TITLE
Add option for disabling realtime events

### DIFF
--- a/compute/src/main/java/com/chatalytics/compute/ChatAlyticsEngineMain.java
+++ b/compute/src/main/java/com/chatalytics/compute/ChatAlyticsEngineMain.java
@@ -1,9 +1,7 @@
 package com.chatalytics.compute;
 
 import com.chatalytics.compute.db.dao.ChatAlyticsDAOFactory;
-import com.chatalytics.compute.storm.ChatAlyticsService;
 import com.chatalytics.compute.storm.ChatAlyticsStormTopology;
-import com.chatalytics.compute.web.realtime.ComputeRealtimeServer;
 import com.chatalytics.compute.web.realtime.ComputeRealtimeServerFactory;
 import com.chatalytics.core.CommonCLIBuilder;
 import com.chatalytics.core.config.ChatAlyticsConfig;
@@ -39,11 +37,10 @@ public class ChatAlyticsEngineMain {
         LOG.info("Loading config {}", configName);
         ChatAlyticsConfig config = YamlUtils.readChatAlyticsConfig(configName);
 
-        StormTopology stormTopology = ChatAlyticsStormTopology.create(config.inputType);
-        ComputeRealtimeServer rtServer =
-            ComputeRealtimeServerFactory.createComputeRealtimeServer(config);
-        ChatAlyticsService chatalyticsService = new ChatAlyticsService(stormTopology, rtServer,
-                                                                       config);
+        StormTopology stormTopology = ChatAlyticsStormTopology.create(config);
+        ComputeRealtimeServerFactory rtServerFactory = new ComputeRealtimeServerFactory(config);
+        ChatAlyticsService chatalyticsService =
+                new ChatAlyticsService(stormTopology, rtServerFactory, config);
 
         addShutdownHook(chatalyticsService);
         chatalyticsService.startAsync().awaitRunning();

--- a/compute/src/main/java/com/chatalytics/compute/ChatAlyticsService.java
+++ b/compute/src/main/java/com/chatalytics/compute/ChatAlyticsService.java
@@ -1,8 +1,8 @@
-package com.chatalytics.compute.storm;
+package com.chatalytics.compute;
 
-import com.chatalytics.compute.ChatAlyticsEngineMain;
 import com.chatalytics.compute.config.ConfigurationConstants;
 import com.chatalytics.compute.web.realtime.ComputeRealtimeServer;
+import com.chatalytics.compute.web.realtime.ComputeRealtimeServerFactory;
 import com.chatalytics.core.config.ChatAlyticsConfig;
 import com.chatalytics.core.util.YamlUtils;
 import com.google.common.util.concurrent.AbstractIdleService;
@@ -12,6 +12,7 @@ import org.apache.storm.LocalCluster;
 import org.apache.storm.generated.AlreadyAliveException;
 import org.apache.storm.generated.InvalidTopologyException;
 import org.apache.storm.generated.StormTopology;
+import org.apache.storm.shade.com.google.common.base.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -30,14 +31,18 @@ public class ChatAlyticsService extends AbstractIdleService {
     private final StormTopology chatTopology;
     private LocalCluster cluster;
     private final ChatAlyticsConfig chatalyticsConfig;
-    private final ComputeRealtimeServer rtServer;
+    private final Optional<ComputeRealtimeServer> rtServer;
 
     public ChatAlyticsService(StormTopology chatTopology,
-                              ComputeRealtimeServer rtServer,
+                              ComputeRealtimeServerFactory rtServerFactory,
                               ChatAlyticsConfig chatalyticsConfig) {
         this.chatTopology = chatTopology;
         this.chatalyticsConfig = chatalyticsConfig;
-        this.rtServer = rtServer;
+        if (chatalyticsConfig.computeConfig.enableRealtimeEvents) {
+            this.rtServer = Optional.of(rtServerFactory.createComputeRealtimeServer());
+        } else {
+            this.rtServer = Optional.absent();
+        }
     }
 
     private LocalCluster submitTopology() throws AlreadyAliveException,
@@ -49,9 +54,9 @@ public class ChatAlyticsService extends AbstractIdleService {
 
         // enable backpressure since the spouts can move at a much faster speed than the bolts
         stormConfig.put(Config.TOPOLOGY_BACKPRESSURE_ENABLE, true);
-        stormConfig.put(Config.TOPOLOGY_EXECUTOR_RECEIVE_BUFFER_SIZE, 64);
-        stormConfig.put(Config.TOPOLOGY_EXECUTOR_SEND_BUFFER_SIZE, 64);
-        stormConfig.put(Config.TOPOLOGY_SLEEP_SPOUT_WAIT_STRATEGY_TIME_MS, 100);
+        stormConfig.put(Config.TOPOLOGY_EXECUTOR_RECEIVE_BUFFER_SIZE, 32);
+        stormConfig.put(Config.TOPOLOGY_EXECUTOR_SEND_BUFFER_SIZE, 32);
+        stormConfig.put(Config.TOPOLOGY_SLEEP_SPOUT_WAIT_STRATEGY_TIME_MS, 10 * 1000);
 
         stormConfig.setSkipMissingKryoRegistrations(true);
         stormConfig.put(ConfigurationConstants.CHATALYTICS_CONFIG.txt,
@@ -65,7 +70,10 @@ public class ChatAlyticsService extends AbstractIdleService {
     @Override
     protected void startUp() throws Exception {
         LOG.info("Starting up...");
-        rtServer.startAsync().awaitRunning();
+        if (rtServer.isPresent()) {
+            LOG.info("Starting realtime event server...");
+            rtServer.get().startAsync().awaitRunning();
+        }
         LOG.info("Submitting storm topology...");
         cluster = submitTopology();
     }
@@ -78,6 +86,9 @@ public class ChatAlyticsService extends AbstractIdleService {
         Thread.sleep(2000L);
         LOG.info("Shutting down storm cluster...");
         cluster.shutdown();
-        rtServer.stopAsync().awaitTerminated();
+        if (rtServer.isPresent()) {
+            LOG.info("Shutting down realtime event server...");
+            rtServer.get().stopAsync().awaitTerminated();
+        }
     }
 }

--- a/compute/src/main/java/com/chatalytics/compute/config/ConfigurationConstants.java
+++ b/compute/src/main/java/com/chatalytics/compute/config/ConfigurationConstants.java
@@ -1,5 +1,7 @@
 package com.chatalytics.compute.config;
 
+import com.chatalytics.core.config.ChatAlyticsConfig;
+
 /**
  * Enum that contains configuration property names found in the storm configuration object.
  *
@@ -9,7 +11,7 @@ package com.chatalytics.compute.config;
 public enum ConfigurationConstants {
 
     /**
-     * Property for the {@link HipChalyticsConfig} object.
+     * Property for the {@link ChatAlyticsConfig} object.
      */
     CHATALYTICS_CONFIG("com.chatalytics.config"),
 

--- a/compute/src/main/java/com/chatalytics/compute/web/realtime/ComputeRealtimeServerFactory.java
+++ b/compute/src/main/java/com/chatalytics/compute/web/realtime/ComputeRealtimeServerFactory.java
@@ -21,6 +21,12 @@ import javax.websocket.server.ServerContainer;
  */
 public class ComputeRealtimeServerFactory {
 
+    private final ChatAlyticsConfig config;
+
+    public ComputeRealtimeServerFactory(ChatAlyticsConfig config) {
+        this.config = config;
+    }
+
     /**
      * Creates a new {@link ComputeRealtimeServer}
      *
@@ -28,7 +34,7 @@ public class ComputeRealtimeServerFactory {
      *            The chatalytics config
      * @return A newly created {@link ComputeRealtimeServer}
      */
-    public static ComputeRealtimeServer createComputeRealtimeServer(ChatAlyticsConfig config) {
+    public ComputeRealtimeServer createComputeRealtimeServer() {
         Server server = new Server(config.computeConfig.rtComputePort);
         ServletContextHandler context = new ServletContextHandler(ServletContextHandler.SESSIONS);
         context.setContextPath("/");

--- a/compute/src/test/java/com/chatalytics/compute/ChatAlyticsServiceTest.java
+++ b/compute/src/test/java/com/chatalytics/compute/ChatAlyticsServiceTest.java
@@ -1,0 +1,63 @@
+package com.chatalytics.compute;
+
+import com.chatalytics.compute.storm.ChatAlyticsStormTopology;
+import com.chatalytics.compute.web.realtime.ComputeRealtimeServer;
+import com.chatalytics.compute.web.realtime.ComputeRealtimeServerFactory;
+import com.chatalytics.core.InputSourceType;
+import com.chatalytics.core.config.ChatAlyticsConfig;
+
+import org.apache.storm.generated.StormTopology;
+import org.eclipse.jetty.server.Server;
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests {@link ChatAlyticsService}.
+ *
+ * @author giannis
+ *
+ */
+public class ChatAlyticsServiceTest {
+
+    @Test
+    public void testStartUpShutDown() throws Exception {
+        ChatAlyticsConfig conf = new ChatAlyticsConfig();
+        conf.inputType = InputSourceType.LOCAL_TEST;
+        StormTopology stormTopology = ChatAlyticsStormTopology.create(conf);
+        ComputeRealtimeServerFactory rtServerFactory = mock(ComputeRealtimeServerFactory.class);
+        ComputeRealtimeServer computeRTServer = new ComputeRealtimeServer(new Server());
+        when(rtServerFactory.createComputeRealtimeServer()).thenReturn(computeRTServer);
+        ChatAlyticsService underTest = new ChatAlyticsService(stormTopology, rtServerFactory, conf);
+        underTest.startUp();
+
+        assertTrue(computeRTServer.isRunning());
+        verify(rtServerFactory).createComputeRealtimeServer();
+        verifyNoMoreInteractions(rtServerFactory);
+
+        underTest.shutDown();
+        assertFalse(computeRTServer.isRunning());
+    }
+
+    @Test
+    public void testStartUpShutDown_noRTServer() throws Exception {
+        ChatAlyticsConfig conf = new ChatAlyticsConfig();
+        conf.inputType = InputSourceType.LOCAL_TEST;
+        StormTopology stormTopology = ChatAlyticsStormTopology.create(conf);
+        conf.computeConfig.enableRealtimeEvents = false;
+        ComputeRealtimeServerFactory rtServerFactory = mock(ComputeRealtimeServerFactory.class);
+        ChatAlyticsService underTest = new ChatAlyticsService(stormTopology, rtServerFactory, conf);
+        underTest.startUp();
+
+        verifyZeroInteractions(rtServerFactory);
+
+        underTest.shutDown();
+    }
+
+}

--- a/config/chatalytics-slackbackfill.yaml
+++ b/config/chatalytics-slackbackfill.yaml
@@ -6,6 +6,7 @@ computeConfig:
     filesToRead:
         'com.chatalytics.bolts.sentiment.words': files/sentiment_words.csv
     rtComputePort: 9001
+    enableRealtimeEvents: false
     chatConfig: !!com.chatalytics.core.config.SlackBackfillerConfig
         baseAPIURL: https://slack.com/api/
         authTokens: ['0']

--- a/core/src/main/java/com/chatalytics/core/config/ComputeConfig.java
+++ b/core/src/main/java/com/chatalytics/core/config/ComputeConfig.java
@@ -17,6 +17,8 @@ public class ComputeConfig implements Serializable {
 
     public int rtComputePort = 9000;
 
+    public boolean enableRealtimeEvents = true;
+
     public ChatConfig chatConfig;
 
     /**


### PR DESCRIPTION
- Add an option for enabling and disabling realtime events. This might be useful when backfilling since there's no point in publishing all the realtime events downstream
- Fixing comments in constants class
